### PR TITLE
feat: apply Stitch dark design system and unify fonts

### DIFF
--- a/src/components/blog/Comments.astro
+++ b/src/components/blog/Comments.astro
@@ -8,41 +8,16 @@ interface Props {
 const { slug } = Astro.props;
 ---
 
-<div class="comments-section">
-  <h2 class="comments-title">Comments</h2>
-  <div id="giscus-container" class="giscus-wrapper">
-    <div class="giscus-loading">
-      <p>Loading comments...</p>
+<div class="mt-8">
+  <h2 class="font-headline text-2xl font-bold text-[#dfe2eb] mb-6">Comments</h2>
+  <div id="giscus-container">
+    <div class="flex items-center justify-center min-h-[200px] text-[#849396] font-label text-sm">
+      Loading comments...
     </div>
   </div>
 </div>
 
 <style>
-  .comments-section {
-    margin-top: 4rem;
-    padding-top: 2rem;
-    border-top: 1px solid var(--color-border);
-  }
-
-  .comments-title {
-    font-size: 1.5rem;
-    margin-bottom: 1.5rem;
-    color: var(--color-text);
-  }
-
-  .giscus-wrapper {
-    min-height: 200px;
-  }
-
-  .giscus-loading {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 200px;
-    color: rgb(var(--gray));
-  }
-
-  /* Giscus dark mode sync */
   :global(.giscus-frame) {
     width: 100%;
   }
@@ -61,9 +36,7 @@ const { slug } = Astro.props;
     // Clear loading state
     container.innerHTML = '';
 
-    // Detect theme
-    const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-    const theme = isDark ? 'dark' : 'light';
+    const theme = 'dark';
 
     // Create Giscus script
     const script = document.createElement('script');

--- a/src/components/blog/SeriesNav.astro
+++ b/src/components/blog/SeriesNav.astro
@@ -12,203 +12,54 @@ const prevPost = currentIndex > 0 ? posts[currentIndex - 1] : null;
 const nextPost = currentIndex < posts.length - 1 ? posts[currentIndex + 1] : null;
 ---
 
-<nav class="series-nav glass-card">
-  <div class="series-header">
-    <span class="series-label">Series</span>
-    <h3 class="series-name">{name}</h3>
-    <span class="series-progress">
-      {currentIndex + 1} / {posts.length}
+<nav class="p-6 mb-10 rounded-xl bg-[#1c2026] border border-[#3b494c]/20">
+  <!-- Series Header -->
+  <div class="flex flex-wrap items-center gap-3 mb-4 pb-4 border-b border-[#3b494c]/20">
+    <span class="text-[10px] font-label font-bold uppercase tracking-widest text-[#00e5ff] bg-[#00e5ff]/10 px-2 py-1 rounded">
+      Series
     </span>
+    <h3 class="flex-1 text-base font-bold font-headline text-[#dfe2eb] m-0">{name}</h3>
+    <span class="text-xs font-label text-[#849396]">{currentIndex + 1} / {posts.length}</span>
   </div>
 
-  <div class="series-posts">
+  <!-- Post List -->
+  <div class="flex flex-col gap-1 mb-4">
     {posts.map((post, index) => (
       <a
         href={`/blog/${post.slug}/`}
-        class:list={[
-          'series-post',
-          { active: index === currentIndex },
-          { completed: index < currentIndex },
-        ]}
+        class={`flex items-center gap-3 px-3 py-2.5 rounded-lg no-underline transition-all ${
+          index === currentIndex
+            ? 'bg-[#00e5ff] text-[#00363d]'
+            : index < currentIndex
+            ? 'text-[#849396] hover:bg-[#262a31]'
+            : 'text-[#bac9cc] hover:bg-[#262a31]'
+        }`}
       >
-        <span class="post-number">{index + 1}</span>
-        <span class="post-title">{post.title}</span>
+        <span class={`flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold font-label flex-shrink-0 ${
+          index === currentIndex
+            ? 'bg-white/20 text-[#00363d]'
+            : index < currentIndex
+            ? 'bg-[#00e5ff] text-[#00363d]'
+            : 'bg-[#262a31] text-[#849396]'
+        }`}>{index + 1}</span>
+        <span class="text-sm font-label truncate">{post.title}</span>
       </a>
     ))}
   </div>
 
-  <div class="series-navigation">
+  <!-- Prev/Next -->
+  <div class="grid grid-cols-2 gap-3 pt-4 border-t border-[#3b494c]/20">
     {prevPost ? (
-      <a href={`/blog/${prevPost.slug}/`} class="nav-link prev">
-        <span class="nav-label">Previous</span>
-        <span class="nav-title">{prevPost.title}</span>
+      <a href={`/blog/${prevPost.slug}/`} class="flex flex-col gap-1 p-3 rounded-lg hover:bg-[#262a31] transition-colors no-underline text-left">
+        <span class="text-[10px] font-label uppercase tracking-widest text-[#849396]">Previous</span>
+        <span class="text-sm font-label text-[#00e5ff] truncate">{prevPost.title}</span>
       </a>
-    ) : (
-      <div class="nav-placeholder" />
-    )}
+    ) : <div />}
     {nextPost ? (
-      <a href={`/blog/${nextPost.slug}/`} class="nav-link next">
-        <span class="nav-label">Next</span>
-        <span class="nav-title">{nextPost.title}</span>
+      <a href={`/blog/${nextPost.slug}/`} class="flex flex-col gap-1 p-3 rounded-lg hover:bg-[#262a31] transition-colors no-underline text-right">
+        <span class="text-[10px] font-label uppercase tracking-widest text-[#849396]">Next</span>
+        <span class="text-sm font-label text-[#00e5ff] truncate">{nextPost.title}</span>
       </a>
-    ) : (
-      <div class="nav-placeholder" />
-    )}
+    ) : <div />}
   </div>
 </nav>
-
-<style>
-  .series-nav {
-    padding: 1.5rem;
-    margin: 2rem 0;
-  }
-
-  .series-header {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-    padding-bottom: 1rem;
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .series-label {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--accent);
-    background: var(--accent-light-translucent);
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-  }
-
-  .series-name {
-    flex: 1;
-    margin: 0;
-    font-size: 1.25rem;
-    font-weight: 700;
-  }
-
-  .series-progress {
-    font-size: 0.875rem;
-    color: rgb(var(--gray));
-    font-weight: 500;
-  }
-
-  .series-posts {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .series-post {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem 1rem;
-    border-radius: 12px;
-    text-decoration: none;
-    color: var(--color-text);
-    transition: all 0.2s ease;
-    background: transparent;
-  }
-
-  .series-post:hover {
-    background: var(--accent-light-translucent);
-  }
-
-  .series-post.active {
-    background: var(--accent);
-    color: white;
-  }
-
-  .series-post.completed .post-number {
-    background: var(--accent);
-    color: white;
-  }
-
-  .post-number {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
-    border-radius: 50%;
-    background: rgb(var(--gray-light));
-    font-size: 0.875rem;
-    font-weight: 600;
-    flex-shrink: 0;
-  }
-
-  .series-post.active .post-number {
-    background: rgba(255, 255, 255, 0.2);
-  }
-
-  .post-title {
-    font-size: 0.9rem;
-    line-height: 1.3;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .series-navigation {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--color-border);
-  }
-
-  .nav-link {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    padding: 0.75rem;
-    border-radius: 12px;
-    text-decoration: none;
-    transition: all 0.2s ease;
-  }
-
-  .nav-link:hover {
-    background: var(--accent-light-translucent);
-  }
-
-  .nav-link.prev {
-    text-align: left;
-  }
-
-  .nav-link.next {
-    text-align: right;
-  }
-
-  .nav-label {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: rgb(var(--gray));
-  }
-
-  .nav-title {
-    font-size: 0.9rem;
-    font-weight: 500;
-    color: var(--accent);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .nav-placeholder {
-    min-height: 1px;
-  }
-
-  @media (max-width: 600px) {
-    .series-navigation {
-      grid-template-columns: 1fr;
-    }
-  }
-</style>

--- a/src/components/blog/TagList.astro
+++ b/src/components/blog/TagList.astro
@@ -7,62 +7,28 @@ interface Props {
 
 const { tags, size = 'md', clickable = true } = Astro.props;
 
-const sizeClasses = {
-  sm: 'text-xs px-2 py-0.5',
-  md: 'text-sm px-3 py-1',
-  lg: 'text-base px-4 py-1.5',
-};
+const sizeClass = {
+  sm: 'text-[10px] px-2 py-0.5',
+  md: 'text-xs px-3 py-1',
+  lg: 'text-sm px-4 py-1.5',
+}[size];
 ---
 
 {tags.length > 0 && (
-  <div class="tag-list">
+  <div class="flex flex-wrap gap-2">
     {tags.map((tag) =>
       clickable ? (
-        <a href={`/tags/${tag}/`} class={`tag ${size}`}>
+        <a
+          href={`/tags/${tag}/`}
+          class={`${sizeClass} rounded-full bg-[#00e5ff]/10 text-[#00e5ff] font-label uppercase tracking-wider border border-[#00e5ff]/20 hover:bg-[#00e5ff]/20 transition-colors no-underline`}
+        >
           #{tag}
         </a>
       ) : (
-        <span class={`tag ${size}`}>#{tag}</span>
+        <span class={`${sizeClass} rounded-full bg-[#1c2026] text-[#849396] font-label uppercase tracking-wider border border-[#3b494c]/30`}>
+          #{tag}
+        </span>
       )
     )}
   </div>
 )}
-
-<style>
-  .tag-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  .tag {
-    display: inline-flex;
-    align-items: center;
-    background: var(--accent-light-translucent);
-    color: var(--accent);
-    border-radius: 99px;
-    font-weight: 500;
-    transition: all 0.2s ease;
-    text-decoration: none;
-  }
-
-  a.tag:hover {
-    background: var(--accent);
-    color: white;
-  }
-
-  .tag.sm {
-    font-size: 0.75rem;
-    padding: 0.125rem 0.5rem;
-  }
-
-  .tag.md {
-    font-size: 0.875rem;
-    padding: 0.25rem 0.75rem;
-  }
-
-  .tag.lg {
-    font-size: 1rem;
-    padding: 0.375rem 1rem;
-  }
-</style>

--- a/src/components/common/BaseHead.astro
+++ b/src/components/common/BaseHead.astro
@@ -33,16 +33,6 @@ const {
 } = Astro.props;
 ---
 
-<!-- Theme initialization (prevent flash) -->
-<script is:inline>
-	(function() {
-		const stored = localStorage.getItem('theme');
-		if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-			document.documentElement.setAttribute('data-theme', 'dark');
-		}
-	})();
-</script>
-
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -56,9 +46,79 @@ const {
 />
 <meta name="generator" content={Astro.generator} />
 
-<!-- Font preloads -->
-<link rel="preload" href="/fonts/atkinson-regular.woff" as="font" type="font/woff" crossorigin />
-<link rel="preload" href="/fonts/atkinson-bold.woff" as="font" type="font/woff" crossorigin />
+<!-- Google Fonts: Stitch Design System -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,600;1,6..72,400&family=Space+Grotesk:wght@400;500;700&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
+
+<!-- Tailwind CSS with Stitch Design System Config -->
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries" is:inline></script>
+<script is:inline>
+  tailwind.config = {
+    darkMode: "class",
+    theme: {
+      extend: {
+        colors: {
+          "surface-container-lowest": "#0a0e14",
+          "surface-bright": "#353940",
+          "secondary-container": "#3e4960",
+          "outline-variant": "#3b494c",
+          "primary-container": "#00e5ff",
+          "inverse-primary": "#006875",
+          "surface-container-low": "#181c22",
+          "surface-container-highest": "#31353c",
+          "secondary": "#bbc6e2",
+          "surface-dim": "#10141a",
+          "on-background": "#dfe2eb",
+          "primary-fixed-dim": "#00daf3",
+          "tertiary-container": "#b9d3f5",
+          "surface": "#10141a",
+          "on-primary-container": "#00626e",
+          "on-secondary": "#263046",
+          "on-secondary-container": "#adb8d3",
+          "surface-container-high": "#262a31",
+          "surface-container": "#1c2026",
+          "on-surface": "#dfe2eb",
+          "primary-fixed": "#9cf0ff",
+          "inverse-surface": "#dfe2eb",
+          "surface-tint": "#00daf3",
+          "error": "#ffb4ab",
+          "tertiary": "#e3eeff",
+          "inverse-on-surface": "#2d3137",
+          "surface-variant": "#31353c",
+          "primary": "#c3f5ff",
+          "outline": "#849396",
+          "on-primary": "#00363d",
+          "on-surface-variant": "#bac9cc",
+          "background": "#10141a"
+        },
+        fontFamily: {
+          "headline": ["Inter", "sans-serif"],
+          "body": ["Inter", "sans-serif"],
+          "label": ["Inter", "sans-serif"],
+          "mono": ["Space Grotesk", "ui-monospace", "monospace"],
+          "prose": ["Newsreader", "serif"]
+        },
+        borderRadius: {
+          "DEFAULT": "0.25rem",
+          "lg": "0.5rem",
+          "xl": "0.75rem",
+          "full": "9999px"
+        },
+      },
+    },
+  };
+</script>
+
+<!-- Material Symbols style -->
+<style is:inline>
+  .material-symbols-outlined {
+    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+    display: inline-block;
+    vertical-align: middle;
+    line-height: 1;
+  }
+</style>
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,73 +1,28 @@
 ---
-const today = new Date();
+import { SOCIAL_LINKS } from "../../lib/constants";
+const year = new Date().getFullYear();
 ---
 
-<footer>
-  &copy; {today.getFullYear()} Kyoungtea Kim. All rights reserved.
-  <div class="social-links">
-    <a href="https://m.webtoo.ls/@astro" target="_blank">
-      <span class="sr-only">Follow Astro on Mastodon</span>
-      <svg
-        viewBox="0 0 16 16"
-        aria-hidden="true"
-        width="32"
-        height="32"
-        astro-icon="social/mastodon"
-        ><path
-          fill="currentColor"
-          d="M11.19 12.195c2.016-.24 3.77-1.475 3.99-2.603.348-1.778.32-4.339.32-4.339 0-3.47-2.286-4.488-2.286-4.488C12.062.238 10.083.017 8.027 0h-.05C5.92.017 3.942.238 2.79.765c0 0-2.285 1.017-2.285 4.488l-.002.662c-.004.64-.007 1.35.011 2.091.083 3.394.626 6.74 3.78 7.57 1.454.383 2.703.463 3.709.408 1.823-.1 2.847-.647 2.847-.647l-.06-1.317s-1.303.41-2.767.36c-1.45-.05-2.98-.156-3.215-1.928a3.614 3.614 0 0 1-.033-.496s1.424.346 3.228.428c1.103.05 2.137-.064 3.188-.189zm1.613-2.47H11.13v-4.08c0-.859-.364-1.295-1.091-1.295-.804 0-1.207.517-1.207 1.541v2.233H7.168V5.89c0-1.024-.403-1.541-1.207-1.541-.727 0-1.091.436-1.091 1.296v4.079H3.197V5.522c0-.859.22-1.541.66-2.046.456-.505 1.052-.764 1.793-.764.856 0 1.504.328 1.933.983L8 4.39l.417-.695c.429-.655 1.077-.983 1.934-.983.74 0 1.336.259 1.791.764.442.505.661 1.187.661 2.046v4.203z"
-        ></path></svg
-      >
+<footer class="w-full mt-20 px-8 flex flex-col items-center gap-6 bg-[#10141a] py-12 border-t border-[#3b494c]/20 pb-20 md:pb-12">
+  <div class="flex flex-wrap justify-center gap-8">
+    <a href={SOCIAL_LINKS.github} target="_blank" rel="noopener noreferrer"
+      class="font-mono text-[10px] uppercase tracking-widest text-slate-600 hover:text-[#00e5ff] underline-offset-4 hover:underline transition-all opacity-80 hover:opacity-100">
+      GitHub
     </a>
-    <a href="https://twitter.com/astrodotbuild" target="_blank">
-      <span class="sr-only">Follow Astro on Twitter</span>
-      <svg
-        viewBox="0 0 16 16"
-        aria-hidden="true"
-        width="32"
-        height="32"
-        astro-icon="social/twitter"
-        ><path
-          fill="currentColor"
-          d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z"
-        ></path></svg
-      >
+    <a href={`mailto:${SOCIAL_LINKS.email}`}
+      class="font-mono text-[10px] uppercase tracking-widest text-slate-600 hover:text-[#00e5ff] underline-offset-4 hover:underline transition-all opacity-80 hover:opacity-100">
+      Email
     </a>
-    <a href="https://github.com/withastro/astro" target="_blank">
-      <span class="sr-only">Go to Astro's GitHub repo</span>
-      <svg
-        viewBox="0 0 16 16"
-        aria-hidden="true"
-        width="32"
-        height="32"
-        astro-icon="social/github"
-        ><path
-          fill="currentColor"
-          d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-        ></path></svg
-      >
+    <a href="/rss.xml" target="_blank"
+      class="font-mono text-[10px] uppercase tracking-widest text-slate-600 hover:text-[#00e5ff] underline-offset-4 hover:underline transition-all opacity-80 hover:opacity-100">
+      RSS
+    </a>
+    <a href={SOCIAL_LINKS.tistory} target="_blank" rel="noopener noreferrer"
+      class="font-mono text-[10px] uppercase tracking-widest text-slate-600 hover:text-[#00e5ff] underline-offset-4 hover:underline transition-all opacity-80 hover:opacity-100">
+      Tistory
     </a>
   </div>
+  <p class="font-mono text-[10px] uppercase tracking-widest text-slate-600 text-center">
+    © {year} Kyoungtae Kim. Built with Astro.
+  </p>
 </footer>
-<style>
-  footer {
-    padding: 1em 1em 1em 1em;
-    margin-top: 24px;
-    background: linear-gradient(var(--gray-gradient)) no-repeat;
-    color: rgb(var(--gray));
-    text-align: center;
-  }
-  .social-links {
-    display: flex;
-    justify-content: center;
-    gap: 1em;
-    margin-top: 1em;
-  }
-  .social-links a {
-    text-decoration: none;
-    color: rgb(var(--gray));
-  }
-  .social-links a:hover {
-    color: rgb(var(--gray-dark));
-  }
-</style>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,116 +1,71 @@
 ---
-import { SITE_TITLE } from "../../lib/constants";
-import HeaderLink from "./HeaderLink.astro";
-import ThemeToggle from "../ui/ThemeToggle.astro";
-import Search from "../ui/Search.astro";
+import { SITE_TITLE, NAV_LINKS } from "../../lib/constants";
+const pathname = Astro.url.pathname;
+const navIcons: Record<string, string> = {
+  '/': 'home',
+  '/blog': 'article',
+  '/news': 'newspaper',
+  '/projects': 'grid_view',
+  '/about': 'person',
+};
 ---
 
-<header>
-  <nav>
-    <h2><a href="/">{SITE_TITLE}</a></h2>
-    <div class="nav-right">
-      <div class="internal-links">
-        <HeaderLink href="/">Home</HeaderLink>
-        <HeaderLink href="/blog">Blog</HeaderLink>
-        <HeaderLink href="/news">News</HeaderLink>
-        <HeaderLink href="/projects">Projects</HeaderLink>
-        <HeaderLink href="/about">About</HeaderLink>
+<header class="fixed top-0 w-full z-50 bg-[#10141a]/60 backdrop-blur-xl shadow-[0px_24px_48px_rgba(0,218,243,0.04)]">
+  <div class="flex justify-between items-center w-full px-6 py-4 max-w-7xl mx-auto">
+    <!-- Logo -->
+    <a href="/" class="text-xl font-bold tracking-tighter text-[#00e5ff] font-headline no-underline hover:opacity-80 transition-opacity">
+      {SITE_TITLE}
+    </a>
+
+    <!-- Desktop Nav -->
+    <nav class="hidden md:flex items-center gap-8 font-label text-xs uppercase tracking-widest">
+      {NAV_LINKS.map((link) => {
+        const isActive = pathname === link.href || (link.href !== '/' && pathname.startsWith(link.href));
+        return (
+          <a
+            href={link.href}
+            class={isActive
+              ? "text-[#00e5ff] border-b-2 border-[#00e5ff] pb-1"
+              : "text-slate-400 hover:text-slate-100 transition-colors"}
+          >
+            {link.label}
+          </a>
+        );
+      })}
+    </nav>
+
+    <!-- Right Actions -->
+    <div class="flex items-center gap-3">
+      <!-- Search box -->
+      <div class="relative hidden sm:block">
+        <span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-[#849396] text-base">search</span>
+        <input
+          id="search-input"
+          type="text"
+          placeholder="Search..."
+          class="bg-[#0a0e14] border border-[#3b494c]/40 rounded-lg pl-10 pr-4 py-2 text-sm font-label text-[#dfe2eb] placeholder-[#849396] focus:ring-1 focus:ring-[#00e5ff]/40 focus:outline-none w-52 transition-all"
+        />
       </div>
-      <Search />
-      <ThemeToggle />
+      <!-- Mobile search icon -->
+      <button class="sm:hidden text-slate-400 hover:text-[#00e5ff] transition-colors" aria-label="검색">
+        <span class="material-symbols-outlined">search</span>
+      </button>
     </div>
-  </nav>
+  </div>
 </header>
 
-<style>
-  header {
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    margin: 0;
-    padding: 0.5em 1em;
-    background: var(--header-bg);
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-    border-bottom: 1px solid var(--color-border);
-    transition: var(--transition-theme);
-  }
-
-  h2 {
-    margin: 0;
-    font-size: 1.25em;
-    font-weight: 800;
-    background: linear-gradient(120deg, var(--accent), #b06ab3);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    transition: transform 0.2s ease;
-  }
-
-  h2 a,
-  h2 a.active,
-  h2 a:hover {
-    text-decoration: none !important;
-    display: block;
-    background: transparent !important;
-    -webkit-text-fill-color: transparent !important;
-    color: transparent !important;
-    opacity: 1 !important;
-  }
-
-  nav {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    max-width: 1200px;
-    margin: 0 auto;
-  }
-
-  .nav-right {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-  }
-
-  .internal-links {
-    display: flex;
-    gap: 0.5rem;
-  }
-
-  nav a {
-    padding: 0.5em 1em;
-    color: var(--color-text);
-    border-bottom: none;
-    text-decoration: none;
-    font-weight: 500;
-    border-radius: 99px;
-    transition: all 0.2s ease;
-    font-size: 0.95rem;
-  }
-
-  nav a.active {
-    text-decoration: none;
-    background-color: var(--accent);
-    color: white;
-  }
-
-  .internal-links a:not(.active):hover {
-    background-color: rgb(var(--gray-light));
-    color: var(--accent);
-  }
-
-  h2:hover {
-    cursor: pointer;
-    transform: scale(1.02);
-  }
-
-  @media (max-width: 720px) {
-    .internal-links {
-      display: none;
-    }
-
-    nav {
-      justify-content: space-between;
-    }
-  }
-</style>
+<!-- Mobile bottom nav -->
+<nav class="md:hidden fixed bottom-0 w-full bg-[#181c22]/90 backdrop-blur-lg border-t border-[#3b494c]/20 py-3 px-6 z-50 flex justify-around">
+  {NAV_LINKS.slice(0, 4).map((link) => {
+    const isActive = pathname === link.href || (link.href !== '/' && pathname.startsWith(link.href));
+    return (
+      <a
+        href={link.href}
+        class={`flex flex-col items-center gap-1 no-underline ${isActive ? 'text-[#00e5ff]' : 'text-slate-500'}`}
+      >
+        <span class="material-symbols-outlined">{navIcons[link.href] || 'circle'}</span>
+        <span class="text-[10px] font-label uppercase">{link.label}</span>
+      </a>
+    );
+  })}
+</nav>

--- a/src/components/layout/SidebarLeft.astro
+++ b/src/components/layout/SidebarLeft.astro
@@ -1,170 +1,83 @@
-<!-- 왼쪽 사이드바 -->
-<aside class="sidebar-left glass-card">
-  <div class="profile-section">
-    <div class="profile-image-container">
-      <img
-        class="profile-photo"
-        src="/images/jerry_profile.jpg"
-        alt="프로필"
-        width="120"
-        height="120"
-        loading="lazy"
-        decoding="async"
-      />
-    </div>
-    <h2 class="profile-name">Jerry</h2>
-    <p class="motto">1인 개발의 꿈을 꾸는<br />열정적인 개발자</p>
+---
+import { CATEGORIES, SOCIAL_LINKS } from "../../lib/constants";
+const pathname = Astro.url.pathname;
+
+const categoryIcons: Record<string, string> = {
+  ml: "hub",
+  llm: "psychology",
+  web: "code",
+  devops: "memory",
+  etc: "more_horiz",
+};
+---
+
+<aside class="fixed left-0 top-0 h-screen pt-20 w-64 hidden lg:flex flex-col bg-[#181c22] z-40">
+  <div class="px-8 py-8">
+    <div class="text-lg font-black text-[#00e5ff] font-headline">Jerry's Archive</div>
+    <div class="text-[10px] font-mono tracking-widest text-[#849396] uppercase opacity-60 mt-1">ML · Web · DevOps</div>
   </div>
 
-  <div class="contact-me">
-    <h3>Connect</h3>
-    <ul>
-      <li>
-        <a href="mailto:rudxo0525@gmail.com" aria-label="Email">
-          <span class="icon">📧</span>
-          <span class="text">Email</span>
-        </a>
-      </li>
-      <li>
-        <a href="tel:+821033671828" aria-label="Phone">
-          <span class="icon">📱</span>
-          <span class="text">+82 10-3367-1828</span>
-        </a>
-      </li>
-      <li>
+  <!-- Category Nav -->
+  <nav class="flex-1 px-4 space-y-1">
+    <a
+      href="/blog"
+      class={`flex items-center gap-3 px-4 py-3 rounded-lg group transition-all ${
+        pathname === '/blog'
+          ? 'bg-[#262a31] text-[#00e5ff] border-l-4 border-[#00e5ff]'
+          : 'text-slate-500 hover:bg-[#262a31]/50 hover:text-slate-300'
+      }`}
+    >
+      <span class="material-symbols-outlined text-xl">article</span>
+      <span class="text-xs font-mono font-label uppercase tracking-wider">All Posts</span>
+    </a>
+
+    {CATEGORIES.map((cat) => {
+      const href = `/categories/${cat.slug}`;
+      const isActive = pathname.startsWith(href);
+      return (
         <a
-          href="https://github.com/KT20201224"
-          target="_blank"
-          rel="noopener noreferrer"
+          href={href}
+          class={`flex items-center gap-3 px-4 py-3 rounded-lg group transition-all ${
+            isActive
+              ? 'bg-[#262a31] text-[#00e5ff] border-l-4 border-[#00e5ff]'
+              : 'text-slate-500 hover:bg-[#262a31]/50 hover:text-slate-300'
+          }`}
         >
-          <span class="icon">🐈‍⬛</span>
-          <span class="text">GitHub</span>
+          <span class="material-symbols-outlined text-xl">{categoryIcons[cat.slug] || 'folder'}</span>
+          <span class="text-xs font-mono font-label uppercase tracking-wider">{cat.label}</span>
         </a>
-      </li>
-      <li>
-        <a
-          href="https://lets-post-it.tistory.com"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span class="icon">📝</span>
-          <span class="text">Tistory</span>
-        </a>
-      </li>
-      <li>
-        <a
-          href="https://velog.io/@rude/posts"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span class="icon">🟩</span>
-          <span class="text">Velog</span>
-        </a>
-      </li>
-    </ul>
+      );
+    })}
+  </nav>
+
+  <!-- Profile card at bottom -->
+  <div class="p-6 mt-auto">
+    <div class="p-4 rounded-xl bg-[#262a31] relative overflow-hidden group">
+      <div class="absolute inset-0 bg-gradient-to-br from-[#00e5ff]/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div>
+      <div class="flex items-center gap-3 relative z-10">
+        <div class="w-10 h-10 rounded-full overflow-hidden border border-[#00e5ff]/20 bg-[#1c2026] flex-shrink-0">
+          <img
+            src="/images/jerry_profile.jpg"
+            alt="Jerry"
+            class="w-full h-full object-cover"
+          />
+        </div>
+        <div>
+          <p class="text-[10px] font-label uppercase tracking-tighter text-[#849396]">Authored by</p>
+          <p class="text-xs font-bold font-headline text-[#dfe2eb]">Kyoungtae Kim</p>
+        </div>
+      </div>
+    </div>
+    <div class="flex gap-3 mt-4 justify-center">
+      <a href={SOCIAL_LINKS.github} target="_blank" rel="noopener noreferrer"
+        class="text-slate-600 hover:text-[#00e5ff] transition-colors text-[10px] font-mono uppercase tracking-widest">
+        GitHub
+      </a>
+      <span class="text-slate-700">·</span>
+      <a href={`mailto:${SOCIAL_LINKS.email}`}
+        class="text-slate-600 hover:text-[#00e5ff] transition-colors text-[10px] font-mono uppercase tracking-widest">
+        Email
+      </a>
+    </div>
   </div>
 </aside>
-
-<style>
-  /* 왼쪽 사이드바 - iOS Widget Style */
-  .sidebar-left {
-    position: sticky;
-    top: 6rem;
-    height: fit-content;
-    padding: 24px;
-    text-align: center;
-    width: 100%;
-    min-width: 250px;
-    box-sizing: border-box;
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-  }
-
-  .profile-section {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .profile-image-container {
-    position: relative;
-    width: 100px;
-    height: 100px;
-    margin-bottom: 0.75rem;
-    border-radius: 22px; /* App Icon Shape */
-    padding: 0;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-  }
-
-  .profile-photo {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: 22px;
-    background: var(--color-bg-secondary);
-  }
-
-  .profile-name {
-    font-size: 22px;
-    margin: 0.5rem 0 0.25rem;
-    font-weight: 700;
-    letter-spacing: -0.5px;
-  }
-  
-  .motto {
-    font-size: 15px;
-    color: rgb(var(--gray));
-    line-height: 1.4;
-    margin: 0;
-  }
-
-  .contact-me {
-    width: 100%;
-    text-align: left;
-  }
-
-  .contact-me h3 {
-    font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: rgb(var(--gray));
-    margin-bottom: 0.5rem;
-    font-weight: 600;
-    padding-left: 0.5rem;
-  }
-
-  .contact-me ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    background: rgba(118, 118, 128, 0.08); /* Grouped List Background */
-    border-radius: 16px;
-    padding: 6px;
-  }
-
-  .contact-me a {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 10px 12px;
-    border-radius: 10px;
-    color: var(--color-text);
-    font-weight: 500;
-    transition: all 0.2s ease;
-    background: transparent;
-    font-size: 15px;
-  }
-
-  .contact-me a:hover {
-    background: var(--color-bg-secondary);
-    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-  }
-  
-  .icon {
-    font-size: 1.2rem;
-  }
-</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,7 +8,7 @@ const blog = defineCollection({
 	schema: ({ image }) =>
 		z.object({
 			title: z.string(),
-			description: z.string().optional(),
+			description: z.string().nullable().optional(),
 			// Transform string to Date object
 			pubDate: z.coerce.date(),
 			updatedDate: z.coerce.date().optional(),
@@ -26,7 +26,7 @@ const news = defineCollection({
 	loader: glob({ base: './src/content/news', pattern: '**/*.{md,mdx}' }),
 	schema: z.object({
 		title: z.string(),
-		description: z.string().optional(),
+		description: z.string().nullable().optional(),
 		pubDate: z.coerce.date(),
 	}),
 });

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -4,6 +4,7 @@ import type { ImageMetadata } from "astro";
 import BaseHead from "../components/common/BaseHead.astro";
 import Footer from "../components/layout/Footer.astro";
 import Header from "../components/layout/Header.astro";
+import SidebarLeft from "../components/layout/SidebarLeft.astro";
 
 interface Props {
   title: string;
@@ -14,63 +15,28 @@ interface Props {
 const { title, description, heroImage } = Astro.props;
 ---
 
-<html lang="ko">
+<html class="dark" lang="ko">
   <head>
     <BaseHead title={title} description={description} />
-    <style>
-      main {
-        width: calc(100% - 2em);
-        max-width: 100%;
-        margin: 0;
-      }
-      .hero-image {
-        width: 100%;
-      }
-      .hero-image img {
-        display: block;
-        margin: 0 auto;
-        border-radius: 12px;
-        box-shadow: var(--box-shadow);
-      }
-      .prose {
-        width: 1000px;
-        max-width: calc(100% - 2em);
-        margin: auto;
-        padding: 1em;
-        color: rgb(var(--gray-dark));
-      }
-      .title {
-        margin-bottom: 1em;
-        padding: 1em 0;
-        text-align: center;
-        line-height: 1;
-      }
-      .title h1 {
-        margin: 0 0 0.5em 0;
-      }
-    </style>
   </head>
 
-  <body>
+  <body class="font-body selection:bg-[#00e5ff] selection:text-[#00363d]">
     <Header />
-    <main>
-      <article>
-        <div class="hero-image">
-          {
-            heroImage && (
-              <Image width={1020} height={510} src={heroImage} alt="" />
-            )
-          }
-        </div>
-        <div class="prose">
-          <div class="title">
-            <h1>{title}</h1>
-            <hr />
+    <div class="flex max-w-7xl mx-auto pt-24 min-h-screen">
+      <SidebarLeft />
+      <main class="flex-1 lg:ml-64 px-6 md:px-12 py-8 pb-24 md:pb-8">
+        <article class="max-w-3xl mx-auto">
+          {heroImage && (
+            <div class="mb-12 rounded-xl overflow-hidden">
+              <Image width={1020} height={510} src={heroImage} alt="" class="w-full object-cover" style="border-radius: 0.75rem; margin: 0;" />
+            </div>
+          )}
+          <div class="prose max-w-none">
+            <slot />
           </div>
-          <slot />
-        </div>
-      </article>
-    </main>
+        </article>
+      </main>
+    </div>
     <Footer />
   </body>
 </html>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -5,11 +5,9 @@ import BaseHead from "../components/common/BaseHead.astro";
 import Footer from "../components/layout/Footer.astro";
 import FormattedDate from "../components/common/FormattedDate.astro";
 import Header from "../components/layout/Header.astro";
-import TagList from "../components/blog/TagList.astro";
-import TOC from "../components/blog/TOC.astro";
+import SidebarLeft from "../components/layout/SidebarLeft.astro";
 import SeriesNav from "../components/blog/SeriesNav.astro";
-import Comments from "../components/blog/Comments.astro";
-import { getCategoryLabel, getSeriesInfo, getPublishedPosts } from "../lib/utils";
+import { getSeriesInfo, getPublishedPosts } from "../lib/utils";
 
 interface Heading {
   depth: number;
@@ -46,15 +44,14 @@ const {
   currentPost,
 } = Astro.props;
 
-// Get series info if applicable
 const seriesInfo = currentPost && series
   ? getSeriesInfo(getPublishedPosts(allPosts), currentPost)
   : null;
 
-const hasTOC = headings.length > 0;
+const h2Headings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 ---
 
-<html lang="ko">
+<html class="dark" lang="ko">
   <head>
     <BaseHead
       title={title}
@@ -65,177 +62,175 @@ const hasTOC = headings.length > 0;
       modifiedTime={updatedDate}
       tags={tags}
     />
-    <style>
-      .post-layout {
-        display: grid;
-        grid-template-columns: 1fr minmax(auto, 840px) 1fr;
-        gap: 2rem;
-        max-width: 1400px;
-        margin: 0 auto;
-        padding: 2rem 1rem;
-      }
-
-      .post-sidebar-left {
-        display: block;
-      }
-
-      .post-main {
-        min-width: 0;
-      }
-
-      .post-sidebar-right {
-        position: relative;
-        max-width: 250px;
-      }
-
-      @media (max-width: 1200px) {
-        .post-layout {
-          grid-template-columns: 1fr;
-          max-width: 900px;
-        }
-        .post-sidebar-left,
-        .post-sidebar-right {
-          display: none;
-        }
-      }
-
-      .hero-image {
-        width: 100%;
-        margin-bottom: 2rem;
-      }
-
-      .hero-image img {
-        display: block;
-        margin: 0 auto;
-        border-radius: 12px;
-        box-shadow: var(--box-shadow);
-      }
-
-      .content-wrapper {
-        padding: 2.5rem;
-      }
-
-      @media (max-width: 720px) {
-        .content-wrapper {
-          padding: 1.5rem;
-        }
-      }
-
-      .prose {
-        width: 100%;
-        color: rgb(var(--gray-dark));
-      }
-
-      .title {
-        margin-bottom: 2rem;
-        padding-bottom: 1.5rem;
-        text-align: center;
-        border-bottom: 1px solid var(--color-border);
-      }
-
-      .title h1 {
-        margin: 0.5rem 0 1rem;
-        font-size: 2.5rem;
-        line-height: 1.1;
-      }
-
-      .date {
-        margin-bottom: 0.5em;
-        color: rgb(var(--gray));
-        font-size: 0.95rem;
-      }
-
-      .last-updated-on {
-        font-style: italic;
-      }
-
-      .post-meta {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        gap: 1rem;
-        margin-top: 1rem;
-      }
-
-      .category-badge {
-        display: inline-flex;
-        align-items: center;
-        padding: 0.25rem 0.75rem;
-        background: rgb(var(--gray-light));
-        color: rgb(var(--gray-dark));
-        border-radius: 99px;
-        font-size: 0.875rem;
-        font-weight: 500;
-        text-decoration: none;
-        transition: all 0.2s ease;
-      }
-
-      .category-badge:hover {
-        background: var(--accent-light-translucent);
-        color: var(--accent);
-      }
-
-      .tags-wrapper {
-        display: flex;
-        justify-content: center;
-        margin-top: 1rem;
-      }
-    </style>
   </head>
 
-  <body>
+  <body class="font-body selection:bg-[#00e5ff] selection:text-[#00363d]">
     <Header />
-    <div class="post-layout">
-      <aside class="post-sidebar-left"></aside>
 
-      <main class="post-main animate-fade-in-up">
-        <article>
-          {heroImage && (
-            <div class="hero-image">
-              <Image width={1020} height={510} src={heroImage} alt="" />
-            </div>
-          )}
+    <div class="pt-24 max-w-7xl mx-auto">
+      <div class="flex">
+        <SidebarLeft />
 
-          <div class="content-wrapper glass-card">
-            <div class="prose">
-              <div class="title">
-                <div class="date">
-                  <FormattedDate date={pubDate} />
-                  {updatedDate && (
-                    <div class="last-updated-on">
-                      Last updated on <FormattedDate date={updatedDate} />
-                    </div>
-                  )}
-                </div>
-                <h1>{title}</h1>
-                <div class="post-meta">
-                  {category && (
-                    <a href={`/categories/${category}/`} class="category-badge">
-                      {getCategoryLabel(category)}
+        <main class="flex-1 lg:ml-64 px-6 md:px-12 py-8 pb-24 md:pb-8">
+          <div class={`max-w-7xl mx-auto grid grid-cols-1 gap-12 ${h2Headings.length > 0 ? 'xl:grid-cols-[1fr_240px]' : ''}`}>
+
+            <!-- Main Article -->
+            <article class="max-w-3xl w-full">
+              <!-- Breadcrumb + Title -->
+              <header class="mb-16">
+                {category && (
+                  <nav class="flex gap-2 mb-6 font-label text-[10px] uppercase tracking-widest text-[#00daf3]">
+                    <a href="/blog" class="hover:text-[#00e5ff] transition-colors no-underline">Blog</a>
+                    <span class="text-slate-700">/</span>
+                    <a href={`/categories/${category}`} class="hover:text-[#00e5ff] transition-colors no-underline">
+                      {category}
                     </a>
-                  )}
-                </div>
-                {tags.length > 0 && (
-                  <div class="tags-wrapper">
-                    <TagList tags={tags} size="md" />
-                  </div>
+                  </nav>
                 )}
-              </div>
+
+                <h1 class="font-headline text-4xl md:text-5xl font-extrabold tracking-tight mb-8 leading-[1.1] text-[#dfe2eb]">
+                  {title}
+                </h1>
+
+                <div class="flex items-center justify-between py-6 border-y border-[#3b494c]/20">
+                  <div class="flex items-center gap-4">
+                    <div class="w-10 h-10 rounded-full overflow-hidden border border-[#00e5ff]/20 bg-[#1c2026] flex-shrink-0">
+                      <img src="/images/jerry_profile.jpg" alt="Jerry" class="w-full h-full object-cover" />
+                    </div>
+                    <div>
+                      <p class="font-label text-sm font-bold text-[#dfe2eb]">Kyoungtae Kim</p>
+                      <p class="font-label text-xs text-[#849396]">Jerry Blog</p>
+                    </div>
+                  </div>
+                  <div class="text-right font-label text-xs text-[#849396]">
+                    <p class="uppercase tracking-widest"><FormattedDate date={pubDate} /></p>
+                    {updatedDate && (
+                      <p class="text-[10px] italic font-body lowercase tracking-normal text-[#3b494c] mt-1">
+                        updated <FormattedDate date={updatedDate} />
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </header>
+
+              <!-- Hero Image -->
+              {heroImage && (
+                <div class="mb-12 rounded-xl overflow-hidden">
+                  <Image
+                    width={1020}
+                    height={510}
+                    src={heroImage}
+                    alt={title}
+                    class="w-full object-cover"
+                    style="border-radius: 0.75rem; margin: 0;"
+                  />
+                </div>
+              )}
 
               {seriesInfo && <SeriesNav series={seriesInfo} />}
 
-              <slot />
+              <!-- Article Body -->
+              <div class="prose max-w-none">
+                <slot />
+              </div>
 
-              <Comments />
-            </div>
+              <!-- Tags (mobile) -->
+              {tags.length > 0 && (
+                <div class="mt-12 xl:hidden flex flex-wrap gap-2">
+                  {tags.map((tag) => (
+                    <a
+                      href={`/tags/${tag}`}
+                      class="px-3 py-1.5 rounded-full bg-[#1c2026] text-[#849396] font-label text-xs uppercase tracking-wider border border-[#3b494c]/30 hover:text-[#00e5ff] hover:border-[#00e5ff]/30 transition-colors no-underline"
+                    >
+                      #{tag}
+                    </a>
+                  ))}
+                </div>
+              )}
+
+            </article>
+
+            <!-- TOC Sidebar (right) -->
+            {h2Headings.length > 0 && (
+              <aside class="hidden xl:block sticky top-32 h-fit">
+                <div class="space-y-6">
+                  <div>
+                    <h4 class="font-label text-xs font-bold uppercase tracking-[0.2em] text-[#849396] mb-6">
+                      Table of Contents
+                    </h4>
+                    <ul class="space-y-3 font-label text-sm">
+                      {h2Headings.map((h) => (
+                        <li>
+                          <a
+                            href={`#${h.slug}`}
+                            class={`toc-link text-slate-500 hover:text-[#c3f5ff] transition-colors block no-underline ${h.depth === 3 ? 'pl-4 text-xs' : ''}`}
+                            data-slug={h.slug}
+                          >
+                            {h.text}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  {tags.length > 0 && (
+                    <div class="p-4 bg-[#1c2026] rounded-xl border border-[#3b494c]/20">
+                      <p class="font-label text-[10px] uppercase tracking-widest text-[#00daf3] mb-3">Tags</p>
+                      <div class="flex flex-wrap gap-2">
+                        {tags.map((tag) => (
+                          <a
+                            href={`/tags/${tag}`}
+                            class="px-2 py-1 rounded-full bg-[#262a31] text-[#849396] font-label text-[10px] uppercase tracking-wider hover:text-[#00e5ff] hover:bg-[#00e5ff]/10 transition-colors no-underline"
+                          >
+                            #{tag}
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </aside>
+            )}
+
           </div>
-        </article>
-      </main>
-
-      <aside class="post-sidebar-right">
-        {hasTOC && <TOC headings={headings} />}
-      </aside>
+        </main>
+      </div>
     </div>
+
     <Footer />
+
+    {h2Headings.length > 0 && (
+      <script is:inline>
+        const tocLinks = document.querySelectorAll('.toc-link');
+        const headings = Array.from(document.querySelectorAll('h2[id], h3[id]'));
+
+        function setActive(slug) {
+          tocLinks.forEach((link) => {
+            if (link.dataset.slug === slug) {
+              link.style.color = '#00e5ff';
+              link.style.borderLeft = '2px solid #00e5ff';
+              link.style.paddingLeft = '0.75rem';
+              link.style.marginLeft = '-0.75rem';
+            } else {
+              link.style.color = '';
+              link.style.borderLeft = '';
+              link.style.paddingLeft = '';
+              link.style.marginLeft = '';
+            }
+          });
+        }
+
+        const observer = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) setActive(entry.target.id);
+            });
+          },
+          { rootMargin: '-20% 0px -70% 0px' }
+        );
+
+        headings.forEach((h) => observer.observe(h));
+      </script>
+    )}
   </body>
 </html>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,12 +1,17 @@
 ---
 import AboutHeroImage from "../assets/blog-placeholder-about.jpg";
 import Layout from "../layouts/AboutLayout.astro";
-import * as simpleIcons from "simple-icons";
-
 // === Solved.ac (백준) ===
 const handle = "olly123";
-const res = await fetch(`https://solved.ac/api/v3/user/show?handle=${handle}`);
-const data = await res.json();
+let data: { tier?: number; solvedCount?: number; rating?: number } | null = null;
+try {
+  const res = await fetch(`https://solved.ac/api/v3/user/show?handle=${handle}`);
+  if (res.ok) {
+    data = await res.json();
+  }
+} catch (e) {
+  // API unavailable at build time, show fallback
+}
 
 // === Kaggle (수동 입력) ===
 const kaggleData = {
@@ -197,15 +202,15 @@ const tierNames = [
     <div class="algorithm-stats">
       <div class="algorithm-stat">
         <span class="algorithm-stat-label">Tier</span>
-        <span class="algorithm-stat-value">{tierNames[data.tier]}</span>
+        <span class="algorithm-stat-value">{data ? tierNames[data.tier ?? 0] : '-'}</span>
       </div>
       <div class="algorithm-stat">
         <span class="algorithm-stat-label">Solved</span>
-        <span class="algorithm-stat-value">{data.solvedCount}</span>
+        <span class="algorithm-stat-value">{data?.solvedCount ?? '-'}</span>
       </div>
       <div class="algorithm-stat">
         <span class="algorithm-stat-label">Rating</span>
-        <span class="algorithm-stat-value">{data.rating}</span>
+        <span class="algorithm-stat-value">{data?.rating ?? '-'}</span>
       </div>
     </div>
   </section>
@@ -224,47 +229,49 @@ const tierNames = [
 </Layout>
 
 <style>
+  /* 전체 폰트 기본: Inter (body 상속) */
+  * {
+    font-family: "Inter", sans-serif;
+  }
+
+  .section-divider {
+    border: none;
+    border-top: 1px solid rgba(59, 73, 76, 0.3);
+    margin: 2.5em 0;
+  }
+
   .profile-intro {
     display: flex;
     align-items: flex-start;
     gap: 3em;
     margin-bottom: 1em;
-    padding: 1em;
+    padding: 1.5em;
     border-radius: 12px;
+    background: #1c2026;
+    border: 1px solid rgba(59, 73, 76, 0.3);
   }
 
   .profile-image img {
-    max-width: 200px;
+    max-width: 160px;
     width: 100%;
     height: auto;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  }
-
-  .profile-image .avatar {
-    width: 200px;
-    height: 200px;
-    background: rgb(var(--accent));
-    color: white;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 4rem;
-    font-weight: bold;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   }
 
   .profile-text h2 {
     margin-top: 0;
-    margin-bottom: 1em;
+    margin-bottom: 0.75em;
     font-size: 1.8rem;
-    color: var(--color-text);
+    font-weight: 700;
+    color: #dfe2eb;
   }
 
   .profile-text p {
+    font-size: 0.95rem;
     line-height: 1.7;
-    color: var(--color-text-secondary);
-    margin-bottom: 1em;
+    color: #849396;
+    margin-bottom: 0.75em;
   }
 
   @media (max-width: 768px) {
@@ -275,20 +282,44 @@ const tierNames = [
     }
   }
 
+  /* Section headings */
+  .career-section h2,
+  .activity-section h2,
+  .certification-section h2,
+  .tech-section h2,
+  .baekjoon-section h2,
+  .kaggle-section h2 {
+    margin-top: 0;
+    margin-bottom: 1em;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: #00e5ff;
+  }
+
+  .career-section, .activity-section {
+    margin-bottom: 1em;
+  }
+
+  /* Experience / Activity items */
   .experience-list {
     list-style: none;
     padding: 0;
     margin: 0;
     display: flex;
     flex-direction: column;
-    gap: 2em;
+    gap: 1.5em;
   }
 
   .experience-item {
     padding: 1.5em;
-    background: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
+    background: #1c2026;
+    border: 1px solid rgba(59, 73, 76, 0.3);
     border-radius: 12px;
+    transition: border-color 0.2s;
+  }
+
+  .experience-item:hover {
+    border-color: rgba(0, 229, 255, 0.2);
   }
 
   .experience-header {
@@ -301,61 +332,41 @@ const tierNames = [
 
   .experience-header h3 {
     margin: 0;
-    font-size: 1.2rem;
-    color: var(--color-text);
+    font-size: 1rem;
+    font-weight: 600;
+    color: #dfe2eb;
   }
 
   .period {
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
+    color: #849396;
+    font-size: 0.8rem;
     flex-shrink: 0;
+    font-family: "Space Grotesk", monospace;
+    letter-spacing: 0.03em;
   }
 
   .position {
-    margin: 0 0 1em 0;
-    color: var(--color-text);
+    margin: 0.25em 0 0.75em 0;
+    color: #00e5ff;
     font-weight: 500;
+    font-size: 0.875rem;
   }
 
   .description {
     margin: 0;
     padding-left: 1.5em;
-    color: var(--color-text-secondary);
+    color: #849396;
+    font-size: 0.875rem;
   }
 
   .description li {
-    margin-bottom: 0.5em;
-    line-height: 1.5;
+    margin-bottom: 0.4em;
+    line-height: 1.6;
   }
 
-  .career-section,
-  .activity-section {
-    margin-bottom: 1em;
-  }
-
-  .career-section h2,
-  .activity-section h2 {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    font-size: 1.8rem;
-    color: var(--color-text);
-  }
-
-  @media (max-width: 1024px) {
-    .experience-section {
-      grid-template-columns: 1fr;
-    }
-  }
-
+  /* Certifications */
   .certification-section {
-    margin-bottom: 4em;
-  }
-
-  .certification-section h2 {
-    margin-top: 1em;
     margin-bottom: 1em;
-    font-size: 1.8rem;
-    color: var(--color-text);
   }
 
   .cert-list {
@@ -364,36 +375,44 @@ const tierNames = [
     margin: 0;
     display: flex;
     flex-direction: column;
-    gap: 1.5em;
+    gap: 1em;
   }
 
   .cert-item {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 1.5em;
-    background: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
+    padding: 1.25em 1.5em;
+    background: #1c2026;
+    border: 1px solid rgba(59, 73, 76, 0.3);
     border-radius: 12px;
+    transition: border-color 0.2s;
+  }
+
+  .cert-item:hover {
+    border-color: rgba(0, 229, 255, 0.2);
   }
 
   .cert-info h3 {
-    margin: 0 0 0.5em 0;
-    font-size: 1.1rem;
-    color: var(--color-text);
+    margin: 0 0 0.3em 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #dfe2eb;
   }
 
   .cert-issuer {
     margin: 0;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
+    color: #849396;
+    font-size: 0.8rem;
   }
 
   .cert-date {
-    color: var(--color-text);
+    color: #00e5ff;
     font-weight: 500;
     flex-shrink: 0;
     margin-left: 1em;
+    font-family: "Space Grotesk", monospace;
+    font-size: 0.875rem;
   }
 
   @media (max-width: 768px) {
@@ -404,15 +423,9 @@ const tierNames = [
     }
   }
 
-  /* Tech Stack - Badge Style */
+  /* Tech Stack */
   .tech-section {
-    margin-bottom: 2em;
-  }
-
-  .tech-section h2 {
-    font-size: 1.8rem;
-    margin-bottom: 1.5em;
-    color: var(--color-text);
+    margin-bottom: 1em;
   }
 
   .tech-category {
@@ -420,10 +433,13 @@ const tierNames = [
   }
 
   .tech-category h3 {
-    font-size: 1rem;
-    color: var(--color-text-secondary);
+    font-size: 0.7rem;
+    color: #849396;
     margin-bottom: 0.75em;
-    font-weight: 500;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-family: "Space Grotesk", monospace;
   }
 
   .tech-badges {
@@ -436,52 +452,64 @@ const tierNames = [
     display: inline-flex;
     align-items: center;
     gap: 0.5em;
-    padding: 0.5em 1em;
-    background: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
+    padding: 0.45em 1em;
+    background: #262a31;
+    border: 1px solid rgba(59, 73, 76, 0.3);
     border-radius: 99px;
-    font-size: 0.9rem;
-    color: var(--color-text);
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: #bac9cc;
+    transition: border-color 0.2s, color 0.2s;
+    line-height: 1;
+  }
+
+  .tech-badge:hover {
+    border-color: rgba(0, 229, 255, 0.3);
+    color: #00e5ff;
   }
 
   .tech-badge img {
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+    flex-shrink: 0;
   }
 
   /* Algorithm & Kaggle */
   .baekjoon-section,
   .kaggle-section {
-    margin-bottom: 2em;
-  }
-
-  .baekjoon-section h2,
-  .kaggle-section h2 {
-    font-size: 1.8rem;
-    margin-bottom: 1.5em;
-    color: var(--color-text);
+    margin-bottom: 1em;
   }
 
   .algorithm-stats {
     display: flex;
-    gap: 3em;
+    gap: 1.5em;
+    flex-wrap: wrap;
   }
 
   .algorithm-stat {
     display: flex;
     flex-direction: column;
-    gap: 0.25em;
+    gap: 0.4em;
+    padding: 1.25em 2em;
+    background: #1c2026;
+    border: 1px solid rgba(59, 73, 76, 0.3);
+    border-radius: 12px;
+    min-width: 120px;
   }
 
   .algorithm-stat-label {
-    font-size: 0.85rem;
-    color: var(--color-text-secondary);
+    font-size: 0.7rem;
+    color: #849396;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-family: "Space Grotesk", monospace;
   }
 
   .algorithm-stat-value {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--color-text);
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #00e5ff;
   }
 
   @media (max-width: 480px) {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,206 +1,134 @@
 ---
-import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
 import BaseHead from '../../components/common/BaseHead.astro';
 import Footer from '../../components/layout/Footer.astro';
 import FormattedDate from '../../components/common/FormattedDate.astro';
 import Header from '../../components/layout/Header.astro';
 import SidebarLeft from '../../components/layout/SidebarLeft.astro';
+import TagList from '../../components/blog/TagList.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../../lib/constants';
 
-const posts = (await getCollection('blog')).sort(
-	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-);
+const posts = (await getCollection('blog'))
+  .filter((p) => !p.data.draft)
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
-// Helper function to extract the first image from markdown body
 function getFirstImage(body: string | undefined) {
   if (!body) return null;
-  const imageRegex = /!\[.*?\]\((.*?)\)/;
-  const match = body.match(imageRegex);
+  const match = body.match(/!\[.*?\]\((.*?)\)/);
   return match ? match[1] : null;
 }
 ---
 
 <!doctype html>
-<html lang="en">
-	<head>
-		<BaseHead title={`Blog - ${SITE_TITLE}`} description={SITE_DESCRIPTION} />
-		<style>
-			/* 2컬럼 레이아웃 (home과 동일) */
-			.layout {
-				display: grid;
-				grid-template-columns: 280px 1fr;
-				gap: 3rem;
-				max-width: 1200px;
-				margin: 0 auto;
-				padding: 2rem 1rem;
-			}
-			.main-content {
-				min-height: 100vh;
-			}
-      
-      .page-header {
-        margin-bottom: 3rem;
-        text-align: center;
-      }
-      
-      .page-header h1 {
-        font-size: 2.5rem;
-        margin-bottom: 0.5rem;
-      }
-      
-      .page-header p {
-        color: var(--gray);
-        font-size: 1.1rem;
-      }
-
-			ul {
-				display: grid;
-				grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-				gap: 2rem;
-				list-style-type: none;
-				margin: 0;
-				padding: 0;
-			}
-      
-			li {
-				transition: all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
-        overflow: hidden;
-        display: flex;
-        flex-direction: column;
-			}
-      
-      li:hover {
-				transform: translateY(-5px);
-        box-shadow: 0 10px 40px -10px rgba(0,0,0,0.15);
-      }
-      
-      /* Active state for touch devices */
-      li:active {
-        transform: scale(0.98);
-      }
-			
-			li a {
-				display: block;
-        text-decoration: none;
-        color: inherit;
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-			}
-      
-      .image-container {
-        width: 100%;
-        aspect-ratio: 16 / 9;
-        overflow: hidden;
-        border-bottom: 1px solid rgba(0,0,0,0.05);
-      }
-      
-      .image-container img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        transition: transform 0.5s ease;
-        margin: 0;
-        border-radius: 0;
-      }
-      
-      li:hover img {
-        transform: scale(1.05);
-      }
-      
-      .content {
-        padding: 1.5rem;
-        flex-grow: 1;
-        display: flex;
-        flex-direction: column;
-      }
-      
-			.title {
-				margin: 0 0 0.5rem;
-				color: var(--black);
-				line-height: 1.2;
-        font-size: 1.25rem;
-        font-weight: 700;
-        transition: color 0.2s ease;
-			}
-      
-      li:hover .title {
-				color: var(--accent);
-			}
-      
-			.date {
-				margin: 0;
-				color: var(--gray);
-        font-size: 0.9rem;
-        margin-bottom: 0.5rem;
-			}
-      
-      .description {
-        margin-top: 0.5rem;
-        font-size: 1rem;
-        color: var(--gray-dark);
-        line-height: 1.5;
-        overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 3;
-        -webkit-box-orient: vertical;
-      }
-      
-			@media (max-width: 1000px) {
-        .layout {
-          grid-template-columns: 1fr;
-          gap: 2rem;
-        }
-				ul {
-					grid-template-columns: 1fr;
-				}
-			}
-		</style>
-	</head>
-	<body>
-		<Header />
-    <div class="layout">
+<html class="dark" lang="ko">
+  <head>
+    <BaseHead title={`Blog | ${SITE_TITLE}`} description={SITE_DESCRIPTION} />
+  </head>
+  <body class="font-body selection:bg-[#00e5ff] selection:text-[#00363d]">
+    <Header />
+    <div class="flex max-w-7xl mx-auto pt-24 min-h-screen">
       <SidebarLeft />
-      <main class="main-content">
-        <section class="page-header animate-fade-in-up">
-          <h1>Blog</h1>
-          <p>개발 경험과 지식을 공유합니다.</p>
-        </section>
-			  <section class="animate-fade-in-up" style="animation-delay: 0.1s">
-				  <ul>
-					  {
-						  posts.map((post) => {
-                const firstImage = getFirstImage(post.body);
-                const displayImage = post.data.heroImage || firstImage;
-                
-                return (
-							  <li class="glass-card">
-								  <a href={`/blog/${post.id}/`}>
-                    <div class="image-container">
-                      {displayImage ? (
-                        <img src={typeof displayImage === 'string' ? displayImage : displayImage.src} alt="" width="720" height="360" loading="lazy" />
-                      ) : (
-                        <div style="width:100%; height:100%; background: linear-gradient(135deg, #e0e7ff 0%, #f5f3ff 100%); display:flex; align-items:center; justify-content:center; color: var(--accent);">
-                           <span style="font-size: 2rem; font-weight:bold; opacity:0.3;">Jerry</span>
-                        </div>
+
+      <main class="flex-1 lg:ml-64 px-6 md:px-12 py-8 pb-24 md:pb-8">
+
+        <!-- Page Header -->
+        <header class="mb-16">
+          <span class="font-label text-xs uppercase tracking-[0.3em] text-[#00e5ff] mb-4 block">Index of Knowledge</span>
+          <div class="flex flex-col md:flex-row md:items-end justify-between gap-6">
+            <div>
+              <h1 class="text-5xl md:text-6xl font-extrabold font-headline tracking-tighter text-[#dfe2eb] leading-tight">
+                Latest <br/>
+                <span class="text-transparent bg-clip-text" style="background-image: linear-gradient(135deg, #c3f5ff 0%, #00e5ff 100%)">
+                  Articles.
+                </span>
+              </h1>
+            </div>
+            <div class="flex gap-4">
+              <div class="flex items-center gap-2 px-4 py-2 bg-[#1c2026] rounded-lg font-label text-xs text-[#849396]">
+                <span class="material-symbols-outlined text-sm">article</span>
+                총 {posts.length}개의 글
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <!-- Post Listing (Stitch style) -->
+        <section class="space-y-12">
+          {posts.map((post) => {
+            const image = post.data.heroImage || getFirstImage(post.body);
+            const imageUrl = image ? (typeof image === 'string' ? image : (image as any).src) : null;
+            return (
+              <article class="group relative grid md:grid-cols-12 gap-8 items-start py-8 transition-all hover:bg-[#181c22]/50 rounded-2xl px-4 -mx-4">
+                {/* Thumbnail */}
+                <div class="md:col-span-4 aspect-video rounded-xl overflow-hidden bg-[#262a31]">
+                  {imageUrl ? (
+                    <img
+                      class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                      src={imageUrl}
+                      alt={post.data.title}
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div class="w-full h-full flex items-center justify-center">
+                      <span class="material-symbols-outlined text-4xl text-[#3b494c]">article</span>
+                    </div>
+                  )}
+                </div>
+
+                {/* Content */}
+                <div class="md:col-span-8 flex flex-col justify-between h-full">
+                  <div>
+                    <div class="flex items-center gap-4 mb-4">
+                      <span class="font-label text-[10px] uppercase tracking-widest text-[#849396]">
+                        <FormattedDate date={post.data.pubDate} />
+                      </span>
+                      {post.data.category && (
+                        <>
+                          <span class="w-1 h-1 rounded-full bg-[#3b494c]"></span>
+                          <span class="font-label text-[10px] uppercase tracking-widest text-[#849396]">
+                            {post.data.category}
+                          </span>
+                        </>
                       )}
                     </div>
-                    <div class="content">
-									    <h4 class="title">{post.data.title}</h4>
-									    <p class="date">
-										    <FormattedDate date={post.data.pubDate} />
-									    </p>
-                      {post.data.description && <p class="description">{post.data.description}</p>}
+                    <a href={`/blog/${post.id}/`} class="no-underline">
+                      <h2 class="text-2xl font-bold font-headline mb-3 text-[#dfe2eb] group-hover:text-[#00e5ff] transition-colors">
+                        {post.data.title}
+                      </h2>
+                    </a>
+                    {post.data.description && (
+                      <p class="text-[#849396] font-body leading-relaxed mb-6 text-lg line-clamp-2">
+                        {post.data.description}
+                      </p>
+                    )}
+                  </div>
+                  {post.data.tags && post.data.tags.length > 0 && (
+                    <div class="flex flex-wrap gap-2">
+                      {post.data.tags.slice(0, 3).map((tag: string) => (
+                        <a
+                          href={`/tags/${tag}`}
+                          class="px-3 py-1 rounded-full bg-[#00e5ff]/10 text-[#00e5ff] font-label text-[10px] uppercase tracking-wider border border-[#00e5ff]/20 hover:bg-[#00e5ff]/20 transition-colors no-underline"
+                        >
+                          {tag}
+                        </a>
+                      ))}
                     </div>
-								  </a>
-							  </li>
-						  )})
-					  }
-				  </ul>
-			  </section>
+                  )}
+                </div>
+              </article>
+            );
+          })}
+        </section>
+
+        {posts.length === 0 && (
+          <div class="text-center py-20">
+            <span class="material-symbols-outlined text-6xl text-[#3b494c] mb-4 block">article</span>
+            <p class="text-[#849396] font-label uppercase tracking-widest text-sm">아직 게시글이 없습니다</p>
+          </div>
+        )}
+
       </main>
     </div>
-		<Footer />
-	</body>
+    <Footer />
+  </body>
 </html>

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -5,9 +5,8 @@ import Header from '../../components/layout/Header.astro';
 import Footer from '../../components/layout/Footer.astro';
 import SidebarLeft from '../../components/layout/SidebarLeft.astro';
 import FormattedDate from '../../components/common/FormattedDate.astro';
-import TagList from '../../components/blog/TagList.astro';
 import { SITE_TITLE, CATEGORIES } from '../../lib/constants';
-import { getPublishedPosts, getPostsByCategory, getCategoryLabel } from '../../lib/utils';
+import { getPublishedPosts, getPostsByCategory } from '../../lib/utils';
 
 export async function getStaticPaths() {
   return CATEGORIES.map((cat) => ({
@@ -16,251 +15,78 @@ export async function getStaticPaths() {
   }));
 }
 
-interface Props {
-  category: string;
-  label: string;
-  description: string;
-}
-
+interface Props { category: string; label: string; description: string; }
 const { category, label, description } = Astro.props;
 const allPosts = await getCollection('blog');
 const publishedPosts = getPublishedPosts(allPosts);
 const posts = getPostsByCategory(publishedPosts, category);
 
-// Helper function to extract the first image from markdown body
 function getFirstImage(body: string | undefined) {
   if (!body) return null;
-  const imageRegex = /!\[.*?\]\((.*?)\)/;
-  const match = body.match(imageRegex);
+  const match = body.match(/!\[.*?\]\((.*?)\)/);
   return match ? match[1] : null;
 }
 ---
 
 <!doctype html>
-<html lang="ko">
+<html class="dark" lang="ko">
   <head>
-    <BaseHead
-      title={`${label} - ${SITE_TITLE}`}
-      description={description}
-    />
-    <style>
-      .layout {
-        display: grid;
-        grid-template-columns: 280px 1fr;
-        gap: 3rem;
-        max-width: 1200px;
-        margin: 0 auto;
-        padding: 2rem 1rem;
-      }
-      .main-content {
-        min-height: 100vh;
-      }
-
-      .page-header {
-        margin-bottom: 3rem;
-        text-align: center;
-      }
-
-      .page-header h1 {
-        font-size: 2.5rem;
-        margin-bottom: 0.5rem;
-      }
-
-      .page-header p {
-        color: rgb(var(--gray));
-        font-size: 1.1rem;
-      }
-
-      .back-link {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        margin-bottom: 1rem;
-        font-size: 0.9rem;
-        color: var(--accent);
-      }
-
-      ul {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-        gap: 2rem;
-        list-style-type: none;
-        margin: 0;
-        padding: 0;
-      }
-
-      li {
-        transition: all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
-        overflow: hidden;
-        display: flex;
-        flex-direction: column;
-      }
-
-      li:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 10px 40px -10px rgba(0, 0, 0, 0.15);
-      }
-
-      li a {
-        display: block;
-        text-decoration: none;
-        color: inherit;
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-      }
-
-      .image-container {
-        width: 100%;
-        aspect-ratio: 16 / 9;
-        overflow: hidden;
-        border-bottom: 1px solid var(--color-border);
-      }
-
-      .image-container img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        transition: transform 0.5s ease;
-        margin: 0;
-        border-radius: 0;
-      }
-
-      li:hover img {
-        transform: scale(1.05);
-      }
-
-      .content {
-        padding: 1.5rem;
-        flex-grow: 1;
-        display: flex;
-        flex-direction: column;
-      }
-
-      .title {
-        margin: 0 0 0.5rem;
-        color: var(--color-text);
-        line-height: 1.2;
-        font-size: 1.25rem;
-        font-weight: 700;
-        transition: color 0.2s ease;
-      }
-
-      li:hover .title {
-        color: var(--accent);
-      }
-
-      .date {
-        margin: 0;
-        color: rgb(var(--gray));
-        font-size: 0.9rem;
-        margin-bottom: 0.5rem;
-      }
-
-      .description {
-        margin-top: 0.5rem;
-        font-size: 1rem;
-        color: rgb(var(--gray-dark));
-        line-height: 1.5;
-        overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 3;
-        -webkit-box-orient: vertical;
-      }
-
-      .tags {
-        margin-top: auto;
-        padding-top: 1rem;
-      }
-
-      .empty-state {
-        text-align: center;
-        padding: 3rem;
-        color: rgb(var(--gray));
-      }
-
-      @media (max-width: 1000px) {
-        .layout {
-          grid-template-columns: 1fr;
-          gap: 2rem;
-        }
-        ul {
-          grid-template-columns: 1fr;
-        }
-      }
-    </style>
+    <BaseHead title={`${label} | ${SITE_TITLE}`} description={description} />
   </head>
-  <body>
+  <body class="font-body selection:bg-[#00e5ff] selection:text-[#00363d]">
     <Header />
-    <div class="layout">
+    <div class="flex max-w-7xl mx-auto pt-24 min-h-screen">
       <SidebarLeft />
-      <main class="main-content">
-        <section class="page-header animate-fade-in-up">
-          <a href="/blog" class="back-link">← Blog로 돌아가기</a>
-          <h1>{label}</h1>
-          <p>{description}</p>
-          <p style="font-size: 0.9rem; margin-top: 0.5rem;">
-            {posts.length}개의 글이 있습니다.
-          </p>
-        </section>
-        <section class="animate-fade-in-up" style="animation-delay: 0.1s">
-          {posts.length > 0 ? (
-            <ul>
-              {posts.map((post) => {
-                const firstImage = getFirstImage(post.body);
-                const displayImage = post.data.heroImage || firstImage;
+      <main class="flex-1 lg:ml-64 px-6 md:px-12 py-8 pb-24 md:pb-8">
+        <header class="mb-12">
+          <a href="/blog" class="inline-flex items-center gap-1 text-[#849396] hover:text-[#00e5ff] transition-colors font-label text-xs uppercase tracking-widest mb-4 no-underline">
+            <span class="material-symbols-outlined text-base">arrow_back</span>
+            Blog
+          </a>
+          <h1 class="text-5xl font-extrabold font-headline tracking-tighter text-[#dfe2eb]">{label}</h1>
+          <p class="text-[#849396] font-body italic mt-2">{description}</p>
+          <p class="text-[#849396] font-label text-xs uppercase tracking-widest mt-1">{posts.length}개의 글</p>
+        </header>
 
-                return (
-                  <li class="glass-card">
-                    <a href={`/blog/${post.id}/`}>
-                      <div class="image-container">
-                        {displayImage ? (
-                          <img
-                            src={
-                              typeof displayImage === 'string'
-                                ? displayImage
-                                : displayImage.src
-                            }
-                            alt=""
-                            width="720"
-                            height="360"
-                            loading="lazy"
-                          />
-                        ) : (
-                          <div
-                            style="width:100%; height:100%; background: linear-gradient(135deg, #e0e7ff 0%, #f5f3ff 100%); display:flex; align-items:center; justify-content:center; color: var(--accent);"
-                          >
-                            <span style="font-size: 2rem; font-weight:bold; opacity:0.3;">
-                              Jerry
-                            </span>
-                          </div>
-                        )}
+        {posts.length > 0 ? (
+          <section class="space-y-10">
+            {posts.map((post) => {
+              const image = post.data.heroImage || getFirstImage(post.body);
+              const imageUrl = image ? (typeof image === 'string' ? image : (image as any).src) : null;
+              return (
+                <article class="group grid md:grid-cols-12 gap-6 items-start py-6 hover:bg-[#181c22]/50 rounded-2xl px-4 -mx-4 transition-all">
+                  <div class="md:col-span-4 aspect-video rounded-xl overflow-hidden bg-[#262a31]">
+                    {imageUrl ? (
+                      <img class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" src={imageUrl} alt={post.data.title} loading="lazy" />
+                    ) : (
+                      <div class="w-full h-full flex items-center justify-center">
+                        <span class="material-symbols-outlined text-4xl text-[#3b494c]">article</span>
                       </div>
-                      <div class="content">
-                        <h4 class="title">{post.data.title}</h4>
-                        <p class="date">
-                          <FormattedDate date={post.data.pubDate} />
-                        </p>
-                        {post.data.description && (
-                          <p class="description">{post.data.description}</p>
-                        )}
-                        {post.data.tags && post.data.tags.length > 0 && (
-                          <div class="tags">
-                            <TagList tags={post.data.tags} size="sm" clickable={false} />
-                          </div>
-                        )}
-                      </div>
+                    )}
+                  </div>
+                  <div class="md:col-span-8">
+                    <div class="flex items-center gap-3 mb-3">
+                      <span class="font-label text-[10px] uppercase tracking-widest text-[#849396]">
+                        <FormattedDate date={post.data.pubDate} />
+                      </span>
+                    </div>
+                    <a href={`/blog/${post.id}/`} class="no-underline">
+                      <h2 class="text-xl font-bold font-headline text-[#dfe2eb] group-hover:text-[#00e5ff] transition-colors mb-2">{post.data.title}</h2>
                     </a>
-                  </li>
-                );
-              })}
-            </ul>
-          ) : (
-            <div class="empty-state">
-              <p>아직 이 카테고리에 글이 없습니다.</p>
-            </div>
-          )}
-        </section>
+                    {post.data.description && (
+                      <p class="text-[#849396] font-body leading-relaxed line-clamp-2">{post.data.description}</p>
+                    )}
+                  </div>
+                </article>
+              );
+            })}
+          </section>
+        ) : (
+          <div class="text-center py-20">
+            <span class="material-symbols-outlined text-6xl text-[#3b494c] mb-4 block">folder_open</span>
+            <p class="text-[#849396] font-label uppercase tracking-widest text-sm">아직 이 카테고리에 글이 없습니다</p>
+          </div>
+        )}
       </main>
     </div>
     <Footer />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,332 +3,160 @@ import { getCollection } from "astro:content";
 import BaseHead from "../components/common/BaseHead.astro";
 import Footer from "../components/layout/Footer.astro";
 import Header from "../components/layout/Header.astro";
-import { SITE_TITLE, SITE_DESCRIPTION } from "../lib/constants";
 import SidebarLeft from "../components/layout/SidebarLeft.astro";
+import FormattedDate from "../components/common/FormattedDate.astro";
+import { SITE_TITLE, SITE_DESCRIPTION } from "../lib/constants";
 
-// 최신 포스트 3개 가져오기
 const posts = (await getCollection("blog"))
+  .filter((p) => !p.data.draft)
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
-  .slice(0, 3);
+  .slice(0, 4);
 
-// 최신 뉴스 3개 가져오기
 const news = (await getCollection("news"))
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
   .slice(0, 3);
-// Helper function to extract the first image from markdown body
+
 function getFirstImage(body: string | undefined) {
   if (!body) return null;
-  const imageRegex = /!\[.*?\]\((.*?)\)/;
-  const match = body.match(imageRegex);
+  const match = body.match(/!\[.*?\]\((.*?)\)/);
   return match ? match[1] : null;
 }
 ---
 
 <!doctype html>
-<html lang="ko">
+<html class="dark" lang="ko">
   <head>
     <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
   </head>
-  <body>
+  <body class="font-body selection:bg-[#00e5ff] selection:text-[#00363d]">
     <Header />
-    <div class="layout">
+    <div class="flex max-w-7xl mx-auto pt-24 min-h-screen">
       <SidebarLeft />
 
-      <!-- 메인 컨텐츠 영역 -->
-      <main class="main-content">
-        <!-- 히어로 섹션 -->
-        <section class="hero animate-fade-in-up">
-          <h1>
-            <span class="text-gradient">안녕하세요, Jerry</span>입니다 👋
-          </h1>
-          <p class="hero-description">
-            기술로 세상을 더 편리하게, <strong>1인 개발의 꿈</strong>을 향해 나아가는 공간입니다.<br />
-            Deep Learning, LLM, 그리고 웹 개발 이야기를 기록합니다.
-          </p>
+      <main class="flex-1 lg:ml-64 px-6 md:px-12 py-8 pb-24 md:pb-8">
+
+        <!-- Hero Section -->
+        <section class="relative w-full min-h-[480px] flex items-center overflow-hidden rounded-2xl mb-16 bg-[#181c22]">
+          <div class="absolute inset-0" style="background: radial-gradient(ellipse at 70% 50%, rgba(0,229,255,0.12) 0%, transparent 60%)"></div>
+          <div class="absolute inset-0 bg-gradient-to-r from-[#181c22] via-[#181c22]/80 to-transparent"></div>
+          <div class="relative z-10 max-w-3xl space-y-6 p-10 md:p-16">
+            <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#00e5ff]/10 border border-[#00e5ff]/20 text-[#00daf3] font-label text-xs uppercase tracking-widest">
+              <span class="w-2 h-2 rounded-full bg-[#00e5ff] animate-pulse"></span>
+              새 글 업로드 중
+            </div>
+            <h1 class="text-5xl md:text-7xl font-black font-headline tracking-tighter text-[#dfe2eb] leading-[0.95]">
+              안녕하세요,<br/>
+              <span class="text-transparent bg-clip-text" style="background-image: linear-gradient(135deg, #c3f5ff 0%, #00e5ff 100%)">
+                Jerry
+              </span>입니다.
+            </h1>
+            <p class="text-xl font-body italic text-[#bac9cc] leading-relaxed max-w-xl">
+              {SITE_DESCRIPTION}
+            </p>
+            <div class="flex flex-wrap gap-4 pt-2">
+              <a href="/blog"
+                class="px-8 py-3 rounded-lg font-label font-bold text-sm tracking-wide text-[#00363d] hover:brightness-110 transition-all active:scale-95 no-underline"
+                style="background: linear-gradient(135deg, #c3f5ff 0%, #00e5ff 100%); box-shadow: 0 8px 24px rgba(0,229,255,0.2)">
+                최신 글 읽기
+              </a>
+              <a href="/about"
+                class="px-8 py-3 rounded-lg border border-[#3b494c]/30 bg-[#1c2026] text-[#dfe2eb] font-label font-bold text-sm hover:bg-[#262a31] transition-all no-underline">
+                소개 보기
+              </a>
+            </div>
+          </div>
         </section>
 
-        <!-- 최신 포스트 섹션 -->
-        <section class="recent-posts animate-fade-in-up" style="animation-delay: 0.2s;">
-          <div class="section-header">
-            <h2>최신 포스트</h2>
-            <a href="/blog" class="view-all">전체 보기 →</a>
+        <!-- Recent Posts -->
+        <section class="mb-16">
+          <div class="flex justify-between items-end mb-10">
+            <div>
+              <h2 class="text-4xl font-headline font-bold text-[#dfe2eb]">최신 포스트</h2>
+              <p class="text-[#849396] font-label text-sm mt-2 uppercase tracking-widest">Recent Posts</p>
+            </div>
+            <a href="/blog"
+              class="text-[#00e5ff] font-label text-sm font-bold flex items-center gap-2 hover:gap-4 transition-all no-underline">
+              전체 보기
+              <span class="material-symbols-outlined text-lg">arrow_forward</span>
+            </a>
           </div>
-          <div class="post-grid">
-            {
-              posts.map((post, index) => {
-                const firstImage = getFirstImage(post.body);
-                const displayImage = post.data.heroImage || firstImage;
-                
-                return (
-                <a 
-                  href={`/blog/${post.id}/`} 
-                  class="post-card glass-card"
-                  style={`animation-delay: ${0.3 + index * 0.1}s`}
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+            {posts.map((post, i) => {
+              const image = post.data.heroImage || getFirstImage(post.body);
+              const isFeatured = i === 0;
+              return (
+                <a
+                  href={`/blog/${post.id}/`}
+                  class={`group space-y-4 cursor-pointer no-underline ${isFeatured ? 'md:col-span-2' : ''}`}
                 >
-                  {displayImage && (
-                    <div class="thumbnail">
-                      <img src={typeof displayImage === 'string' ? displayImage : displayImage.src} alt="" loading="lazy"/>
+                  {image && (
+                    <div class="overflow-hidden rounded-xl bg-[#1c2026] aspect-video">
+                      <img
+                        src={typeof image === 'string' ? image : (image as any).src}
+                        alt={post.data.title}
+                        class="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
+                        loading="lazy"
+                      />
                     </div>
                   )}
-                  <div class="post-content">
-                    <h3>{post.data.title}</h3>
-                    <p class="description">{post.data.description}</p>
-                    <time datetime={post.data.pubDate.toISOString()}>
-                      {post.data.pubDate.toLocaleDateString("ko-KR", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                      })}
-                    </time>
+                  <div class="space-y-2">
+                    <div class="flex items-center gap-4 text-xs font-label font-bold text-[#00daf3] uppercase tracking-wider">
+                      {post.data.category && <span>{post.data.category.toUpperCase()}</span>}
+                      <span class="w-1 h-1 rounded-full bg-[#3b494c]"></span>
+                      <span class="text-[#849396] font-body lowercase tracking-normal font-normal italic">
+                        <FormattedDate date={post.data.pubDate} />
+                      </span>
+                    </div>
+                    <h3 class={`font-headline font-bold text-[#dfe2eb] group-hover:text-[#00e5ff] transition-colors ${isFeatured ? 'text-3xl' : 'text-xl'}`}>
+                      {post.data.title}
+                    </h3>
+                    {post.data.description && (
+                      <p class="text-[#bac9cc] font-body leading-relaxed line-clamp-2">
+                        {post.data.description}
+                      </p>
+                    )}
                   </div>
                 </a>
-              )})
-            }
+              );
+            })}
           </div>
         </section>
-        
-        <!-- 테크 뉴스 섹션 -->
-        <section class="tech-news animate-fade-in-up" style="animation-delay: 0.4s;">
-           <div class="section-header">
-            <h2>Tech News</h2>
-            <a href="/news" class="view-all">전체 보기 →</a>
-          </div>
-          <div class="news-list">
-             {
-              news.map((item) => (
-                <div class="news-item">
-                  <div class="news-header">
-                    <span class="news-date">
-                      {item.data.pubDate.toLocaleDateString("ko-KR", {
-                         month: "short", day: "numeric"
-                      })}
+
+        <!-- Tech News Section -->
+        {news.length > 0 && (
+          <section class="mb-16">
+            <div class="flex justify-between items-end mb-10">
+              <div>
+                <h2 class="text-4xl font-headline font-bold text-[#dfe2eb]">Tech News</h2>
+                <p class="text-[#849396] font-label text-sm mt-2 uppercase tracking-widest">Latest Updates</p>
+              </div>
+              <a href="/news"
+                class="text-[#00e5ff] font-label text-sm font-bold flex items-center gap-2 hover:gap-4 transition-all no-underline">
+                전체 보기
+                <span class="material-symbols-outlined text-lg">arrow_forward</span>
+              </a>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+              {news.map((item) => (
+                <div class="p-6 rounded-xl bg-[#1c2026] border border-[#3b494c]/20 hover:border-[#00e5ff]/20 transition-colors">
+                  <div class="mb-3">
+                    <span class="text-[10px] font-label font-bold text-[#00e5ff] bg-[#00e5ff]/10 px-2 py-1 rounded uppercase tracking-wider">
+                      <FormattedDate date={item.data.pubDate} />
                     </span>
-                    <h3>{item.data.title}</h3>
                   </div>
-                  <p>{item.data.description}</p>
+                  <h3 class="font-headline font-bold text-[#dfe2eb] text-base mb-2 leading-snug">{item.data.title}</h3>
+                  {item.data.description && (
+                    <p class="text-sm text-[#849396] font-body line-clamp-2">{item.data.description}</p>
+                  )}
                 </div>
-              ))
-            }
-          </div>
-        </section>
+              ))}
+            </div>
+          </section>
+        )}
+
       </main>
     </div>
     <Footer />
   </body>
 </html>
-
-<style>
-  /* 2컬럼 레이아웃 */
-  .layout {
-    display: grid;
-    grid-template-columns: 280px 1fr; /* Widen sidebar back */
-    gap: 3rem;
-    max-width: 1200px; /* Constrain width for better reading experience on ultra-wide */
-    margin: 0 auto;
-    padding: 2rem 1rem;
-  }
-
-  /* 메인 컨텐츠 */
-  .main-content {
-    min-height: 100vh;
-    padding-top: 0; /* Remove default padding as layout handles it */
-  }
-
-  /* 히어로 섹션 */
-  .hero {
-    text-align: center;
-    padding: 4rem 1rem;
-    margin-bottom: 4rem;
-  }
-
-  .hero h1 {
-    font-size: 3.5rem;
-    margin-bottom: 1.5rem;
-    line-height: 1.2;
-    letter-spacing: -0.03em;
-  }
-  
-  .text-gradient {
-    background: linear-gradient(120deg, var(--accent), #b06ab3);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    color: transparent;
-  }
-
-  .hero-description {
-    font-size: 1.35rem;
-    color: var(--gray);
-    max-width: 700px;
-    margin: 0 auto;
-    line-height: 1.6;
-  }
-  
-  /* 섹션 공통 */
-  .section-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    margin-bottom: 2rem;
-    padding: 0 0.5rem;
-  }
-  
-  h2 {
-    font-size: 2rem;
-    margin: 0;
-  }
-
-  /* 최신 포스트 Grid */
-  .post-grid {
-    display: grid;
-    grid-template-columns: 1fr; 
-    gap: 1.5rem;
-    margin-bottom: 4rem;
-  }
-
-  .post-card {
-    display: flex;
-    flex-direction: column;
-    text-decoration: none;
-    color: inherit;
-    transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.3s ease;
-    border: 1px solid rgba(255, 255, 255, 0.6);
-    overflow: hidden; /* Ensure image stays within border radius */
-    padding: 0; /* Remove padding from card wrapper so image hits edges */
-  }
-  
-  .thumbnail {
-    width: 100%;
-    aspect-ratio: 16 / 9;
-    overflow: hidden;
-    border-bottom: 1px solid rgba(0,0,0,0.05);
-  }
-  
-  .thumbnail img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 0.5s ease;
-  }
-  
-  .post-card:hover .thumbnail img {
-    transform: scale(1.05);
-  }
-  
-  .post-content {
-    padding: 2rem;
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-  }
-  
-  /* Stagger animation setup */
-  .post-card {
-    opacity: 0;
-    animation: fadeInUp 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-  }
-
-  .post-card:hover {
-    transform: translateY(-5px) scale(1.01);
-    box-shadow: 0 15px 30px -10px rgba(0, 0, 0, 0.1);
-    border-color: rgba(var(--accent-hue), var(--accent-sat), 70%, 0.4);
-  }
-
-  .post-card h3 {
-    margin: 0 0 0.75rem 0;
-    font-size: 1.5rem;
-    color: var(--black);
-    transition: color 0.2s ease;
-  }
-
-  .post-card:hover h3 {
-    color: var(--accent);
-  }
-  
-  .post-card .description {
-    color: var(--gray-dark);
-    font-size: 1.1rem;
-    margin-bottom: 1.5rem;
-    line-height: 1.5;
-    flex-grow: 1; /* Pushes time to bottom if height fixed, good for grid */
-  }
-
-  .post-card time {
-    color: var(--gray);
-    font-size: 0.95rem;
-    font-weight: 500;
-  }
-  
-  /* Tech News */
-  .tech-news {
-    margin-bottom: 4rem;
-  }
-  
-  .news-list {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 1.5rem;
-  }
-  
-  .news-item {
-    background: rgba(255, 255, 255, 0.5);
-    border-radius: 12px;
-    padding: 1.5rem;
-    border: 1px solid rgba(0,0,0,0.05);
-  }
-  
-  .news-header {
-    display: flex;
-    align-items: baseline;
-    gap: 0.75rem;
-    margin-bottom: 0.75rem;
-  }
-  
-  .news-date {
-    font-size: 0.85rem;
-    font-weight: 700;
-    color: var(--accent);
-    background: rgba(var(--accent-hue), var(--accent-sat), var(--accent-light), 0.1);
-    padding: 0.2rem 0.5rem;
-    border-radius: 4px;
-    white-space: nowrap;
-  }
-  
-  .news-item h3 {
-    font-size: 1.1rem;
-    margin: 0;
-    line-height: 1.4;
-  }
-  
-  .news-item p {
-    font-size: 0.95rem;
-    color: var(--gray-dark);
-    margin: 0;
-    line-height: 1.5;
-  }
-
-  .view-all {
-    color: var(--accent);
-    text-decoration: none;
-    font-weight: bold;
-    font-size: 1.1rem;
-    transition: transform 0.2s ease;
-  }
-
-  .view-all:hover {
-    transform: translateX(5px);
-    text-decoration: underline;
-  }
-
-  /* 반응형 */
-  @media (max-width: 1000px) {
-    .layout {
-      grid-template-columns: 1fr;
-      gap: 2rem;
-    }
-
-    .hero h1 {
-      font-size: 2.5rem;
-    }
-  }
-</style>

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -4,139 +4,68 @@ import BaseHead from '../../components/common/BaseHead.astro';
 import Header from '../../components/layout/Header.astro';
 import Footer from '../../components/layout/Footer.astro';
 import SidebarLeft from '../../components/layout/SidebarLeft.astro';
+import FormattedDate from '../../components/common/FormattedDate.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../../lib/constants';
 
 const news = (await getCollection('news')).sort(
-	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
 ---
 
 <!doctype html>
-<html lang="ko">
-	<head>
-		<BaseHead title={`News - ${SITE_TITLE}`} description={SITE_DESCRIPTION} />
-		<style>
-			/* 2컬럼 레이아웃 (home과 동일) */
-			.layout {
-				display: grid;
-				grid-template-columns: 280px 1fr;
-				gap: 3rem;
-				max-width: 1200px;
-				margin: 0 auto;
-				padding: 2rem 1rem;
-			}
-			.main-content {
-				min-height: 100vh;
-			}
-      
-      .page-header {
-        margin-bottom: 3rem;
-        text-align: center;
-      }
-      
-      .page-header h1 {
-        font-size: 2.5rem;
-        margin-bottom: 0.5rem;
-      }
-      
-      .page-header p {
-        color: var(--gray);
-        font-size: 1.1rem;
-      }
-
-			ul {
-				display: grid;
-        grid-template-columns: 1fr;
-				gap: 1.5rem;
-				list-style-type: none;
-				padding: 0;
-			}
-      
-			.news-item {
-        background: var(--glass-bg);
-        backdrop-filter: blur(12px);
-        border: 1px solid var(--glass-border);
-        border-radius: 12px;
-				transition: transform 0.2s ease, box-shadow 0.2s ease;
-        padding: 1.5rem;
-			}
-      
-			.news-item:hover {
-				transform: translateY(-3px);
-        box-shadow: var(--glass-shadow);
-        border-color: rgba(var(--accent-hue), var(--accent-sat), 70%, 0.4);
-			}
-      
-			.news-item a {
-        text-decoration: none;
-        color: inherit;
-        display: block;
-      }
-      
-			.title {
-				margin: 0 0 0.5rem 0;
-				color: var(--black);
-				font-size: 1.5rem;
-        font-weight: 700;
-        transition: color 0.2s ease;
-			}
-      
-      .news-item:hover .title {
-				color: var(--accent);
-			}
-      
-			.date {
-				margin: 0;
-				color: var(--gray);
-        font-size: 0.9rem;
-			}
-      
-      .description {
-        margin-top: 1rem;
-        color: var(--gray-dark);
-        line-height: 1.5;
-      }
-      
-      @media (max-width: 1000px) {
-        .layout {
-          grid-template-columns: 1fr;
-          gap: 2rem;
-        }
-      }
-		</style>
-	</head>
-	<body>
-		<Header />
-    <div class="layout">
+<html class="dark" lang="ko">
+  <head>
+    <BaseHead title={`News | ${SITE_TITLE}`} description={SITE_DESCRIPTION} />
+  </head>
+  <body class="font-body selection:bg-[#00e5ff] selection:text-[#00363d]">
+    <Header />
+    <div class="flex max-w-7xl mx-auto pt-24 min-h-screen">
       <SidebarLeft />
-      <main class="main-content">
-        <section class="page-header animate-fade-in-up">
-          <h1>Tech News</h1>
-          <p>최신 기술 동향과 업데이트를 확인하세요.</p>
-        </section>
-        <section class="animate-fade-in-up" style="animation-delay: 0.1s">
-          <ul>
-            {
-              news.map((post) => (
-                <li class="news-item">
-                  <a href={`/news/${post.id}/`}>
-                    <p class="date">
-                     {post.data.pubDate.toLocaleDateString('ko-KR', {
-                        year: 'numeric',
-                        month: 'long', 
-                        day: 'numeric'
-                      })}
+      <main class="flex-1 lg:ml-64 px-6 md:px-12 py-8 pb-24 md:pb-8">
+        <header class="mb-12">
+          <span class="font-label text-xs uppercase tracking-[0.3em] text-[#00e5ff] mb-4 block">Updates</span>
+          <h1 class="text-5xl font-extrabold font-headline tracking-tighter text-[#dfe2eb]">Tech News</h1>
+          <p class="text-[#849396] font-body italic mt-2">최신 기술 동향과 업데이트</p>
+        </header>
+
+        <section class="space-y-6">
+          {news.map((post) => (
+            <a
+              href={`/news/${post.id}/`}
+              class="block p-6 rounded-xl bg-[#1c2026] border border-[#3b494c]/20 hover:border-[#00e5ff]/20 hover:bg-[#262a31]/50 transition-all group no-underline"
+            >
+              <div class="flex items-start gap-6">
+                <div class="flex-shrink-0 text-center">
+                  <span class="block text-[10px] font-label uppercase tracking-widest text-[#00e5ff] bg-[#00e5ff]/10 px-2 py-1 rounded">
+                    <FormattedDate date={post.data.pubDate} />
+                  </span>
+                </div>
+                <div class="flex-1 min-w-0">
+                  <h2 class="text-xl font-bold font-headline text-[#dfe2eb] group-hover:text-[#00e5ff] transition-colors mb-2">
+                    {post.data.title}
+                  </h2>
+                  {post.data.description && (
+                    <p class="text-[#849396] font-body leading-relaxed line-clamp-2">
+                      {post.data.description}
                     </p>
-                    <h4 class="title">{post.data.title}</h4>
-                    <p class="description">{post.data.description}</p>
-                  </a>
-                </li>
-              ))
-            }
-          </ul>
+                  )}
+                </div>
+                <span class="material-symbols-outlined text-[#3b494c] group-hover:text-[#00e5ff] transition-colors flex-shrink-0">
+                  arrow_forward
+                </span>
+              </div>
+            </a>
+          ))}
+
+          {news.length === 0 && (
+            <div class="text-center py-20">
+              <span class="material-symbols-outlined text-6xl text-[#3b494c] mb-4 block">newspaper</span>
+              <p class="text-[#849396] font-label uppercase tracking-widest text-sm">아직 뉴스가 없습니다</p>
+            </div>
+          )}
         </section>
       </main>
     </div>
-		<Footer />
-	</body>
+    <Footer />
+  </body>
 </html>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -2,121 +2,87 @@
 import BaseHead from "../components/common/BaseHead.astro";
 import Header from "../components/layout/Header.astro";
 import Footer from "../components/layout/Footer.astro";
+import SidebarLeft from "../components/layout/SidebarLeft.astro";
 import { SITE_TITLE } from "../lib/constants";
 
-// 프로젝트 데이터 (나중에 별도 파일로 분리 가능)
 const projects = [
   {
     title: "프로젝트 1",
     description: "프로젝트 설명",
     tech: ["React", "TypeScript"],
-    github: "https://github.com/...",
-    demo: "https://...",
+    github: "https://github.com/KT20201224",
+    demo: "",
   },
-  // 추가 프로젝트들...
 ];
 ---
 
 <!doctype html>
-<html lang="ko">
+<html class="dark" lang="ko">
   <head>
-    <BaseHead title={`Projects | ${SITE_TITLE}`} description="프로젝트 목록" />
+    <BaseHead title={`Projects | ${SITE_TITLE}`} description="프로젝트 포트폴리오" />
   </head>
-  <body>
+  <body class="font-body selection:bg-[#00e5ff] selection:text-[#00363d]">
     <Header />
-    <main class="projects-page">
-      <h1>Projects</h1>
+    <div class="flex max-w-7xl mx-auto pt-24 min-h-screen">
+      <SidebarLeft />
+      <main class="flex-1 lg:ml-64 px-6 md:px-12 py-8 pb-24 md:pb-8">
 
-      <div class="projects-grid">
-        {
-          projects.map((project) => (
-            <article class="project-card">
-              <h2>{project.title}</h2>
-              <p>{project.description}</p>
-              <div class="tech-stack">
-                {project.tech.map((tech) => (
-                  <span class="tech-tag">{tech}</span>
-                ))}
-              </div>
-              <div class="project-links">
-                {project.github && (
-                  <a href={project.github} target="_blank">
-                    GitHub
-                  </a>
-                )}
-                {project.demo && (
-                  <a href={project.demo} target="_blank">
-                    Demo
-                  </a>
-                )}
-              </div>
-            </article>
-          ))
-        }
-      </div>
-    </main>
+        <header class="mb-16">
+          <span class="font-label text-xs uppercase tracking-[0.3em] text-[#00e5ff] mb-4 block">Portfolio</span>
+          <h1 class="text-5xl md:text-6xl font-extrabold font-headline tracking-tighter text-[#dfe2eb] leading-tight">
+            Selected <br/>
+            <span class="text-transparent bg-clip-text" style="background-image: linear-gradient(135deg, #c3f5ff 0%, #00e5ff 100%)">
+              Projects.
+            </span>
+          </h1>
+          <p class="text-xl text-[#849396] font-body italic leading-relaxed mt-4 max-w-2xl">
+            개발한 프로젝트들을 소개합니다.
+          </p>
+        </header>
+
+        <!-- Bento Grid -->
+        <div class="grid grid-cols-1 md:grid-cols-12 gap-8">
+          {projects.map((project, i) => {
+            const isFeatured = i === 0;
+            return (
+              <article class={`${isFeatured ? 'md:col-span-8' : 'md:col-span-4'} group bg-[#1c2026] rounded-xl overflow-hidden flex flex-col hover:shadow-[0px_24px_48px_rgba(0,218,243,0.06)] transition-all duration-500`}>
+                <div class="aspect-video w-full bg-[#262a31] flex items-center justify-center">
+                  <span class="material-symbols-outlined text-6xl text-[#3b494c]">code</span>
+                </div>
+                <div class="p-6 flex flex-col flex-1">
+                  <div class="flex flex-wrap gap-2 mb-4">
+                    {project.tech.map((t) => (
+                      <span class="px-2 py-0.5 rounded bg-[#262a31] text-[10px] font-mono text-slate-400 uppercase">{t}</span>
+                    ))}
+                  </div>
+                  <h3 class={`font-bold font-headline text-[#dfe2eb] group-hover:text-[#00e5ff] transition-colors mb-3 ${isFeatured ? 'text-2xl' : 'text-xl'}`}>
+                    {project.title}
+                  </h3>
+                  <p class="text-[#849396] font-body mb-6 flex-1">{project.description}</p>
+                  <div class="flex gap-3 mt-auto">
+                    {project.github && (
+                      <a href={project.github} target="_blank" rel="noopener noreferrer"
+                        class="flex items-center gap-2 px-4 py-2 bg-[#262a31] text-[#dfe2eb] rounded-lg font-label text-xs hover:bg-[#00e5ff] hover:text-[#00363d] transition-all no-underline">
+                        <span class="material-symbols-outlined text-sm">code</span>
+                        GitHub
+                      </a>
+                    )}
+                    {project.demo && (
+                      <a href={project.demo} target="_blank" rel="noopener noreferrer"
+                        class="flex items-center gap-2 px-4 py-2 bg-[#00e5ff] text-[#00363d] rounded-lg font-label text-xs font-bold hover:brightness-110 transition-all no-underline">
+                        <span class="material-symbols-outlined text-sm">play_circle</span>
+                        Demo
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+
+      </main>
+    </div>
     <Footer />
   </body>
 </html>
-
-<style>
-  .projects-page {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 3em 2em;
-  }
-
-  .projects-page h1 {
-    font-size: 2.5rem;
-    margin-bottom: 2em;
-  }
-
-  .projects-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-    gap: 2em;
-  }
-
-  .project-card {
-    background: rgb(var(--gray-light));
-    padding: 2em;
-    border-radius: 12px;
-    border: 1px solid rgb(var(--gray-lighter));
-  }
-
-  .project-card h2 {
-    margin-top: 0;
-    color: rgb(var(--accent));
-  }
-
-  .tech-stack {
-    display: flex;
-    gap: 0.5em;
-    flex-wrap: wrap;
-    margin: 1em 0;
-  }
-
-  .tech-tag {
-    background: rgb(var(--accent));
-    color: white;
-    padding: 0.25em 0.75em;
-    border-radius: 4px;
-    font-size: 0.9rem;
-  }
-
-  .project-links {
-    display: flex;
-    gap: 1em;
-    margin-top: 1.5em;
-  }
-
-  .project-links a {
-    color: rgb(var(--accent));
-    text-decoration: none;
-    font-weight: 500;
-  }
-
-  .project-links a:hover {
-    text-decoration: underline;
-  }
-</style>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -5,7 +5,6 @@ import Header from '../../components/layout/Header.astro';
 import Footer from '../../components/layout/Footer.astro';
 import SidebarLeft from '../../components/layout/SidebarLeft.astro';
 import FormattedDate from '../../components/common/FormattedDate.astro';
-import TagList from '../../components/blog/TagList.astro';
 import { SITE_TITLE } from '../../lib/constants';
 import { getPublishedPosts, getPostsByTag, getTagsWithCount } from '../../lib/utils';
 
@@ -13,241 +12,75 @@ export async function getStaticPaths() {
   const allPosts = await getCollection('blog');
   const publishedPosts = getPublishedPosts(allPosts);
   const tags = getTagsWithCount(publishedPosts);
-
   return tags.map((tag) => ({
     params: { tag: tag.name },
     props: { tag: tag.name },
   }));
 }
 
-interface Props {
-  tag: string;
-}
-
+interface Props { tag: string; }
 const { tag } = Astro.props;
 const allPosts = await getCollection('blog');
 const publishedPosts = getPublishedPosts(allPosts);
 const posts = getPostsByTag(publishedPosts, tag);
 
-// Helper function to extract the first image from markdown body
 function getFirstImage(body: string | undefined) {
   if (!body) return null;
-  const imageRegex = /!\[.*?\]\((.*?)\)/;
-  const match = body.match(imageRegex);
+  const match = body.match(/!\[.*?\]\((.*?)\)/);
   return match ? match[1] : null;
 }
 ---
 
 <!doctype html>
-<html lang="ko">
+<html class="dark" lang="ko">
   <head>
-    <BaseHead
-      title={`#${tag} - ${SITE_TITLE}`}
-      description={`${tag} 태그가 포함된 글 목록`}
-    />
-    <style>
-      .layout {
-        display: grid;
-        grid-template-columns: 280px 1fr;
-        gap: 3rem;
-        max-width: 1200px;
-        margin: 0 auto;
-        padding: 2rem 1rem;
-      }
-      .main-content {
-        min-height: 100vh;
-      }
-
-      .page-header {
-        margin-bottom: 3rem;
-        text-align: center;
-      }
-
-      .page-header h1 {
-        font-size: 2.5rem;
-        margin-bottom: 0.5rem;
-        color: var(--accent);
-      }
-
-      .page-header p {
-        color: rgb(var(--gray));
-        font-size: 1.1rem;
-      }
-
-      .back-link {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        margin-bottom: 1rem;
-        font-size: 0.9rem;
-        color: var(--accent);
-      }
-
-      ul {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-        gap: 2rem;
-        list-style-type: none;
-        margin: 0;
-        padding: 0;
-      }
-
-      li {
-        transition: all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
-        overflow: hidden;
-        display: flex;
-        flex-direction: column;
-      }
-
-      li:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 10px 40px -10px rgba(0, 0, 0, 0.15);
-      }
-
-      li a {
-        display: block;
-        text-decoration: none;
-        color: inherit;
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-      }
-
-      .image-container {
-        width: 100%;
-        aspect-ratio: 16 / 9;
-        overflow: hidden;
-        border-bottom: 1px solid var(--color-border);
-      }
-
-      .image-container img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        transition: transform 0.5s ease;
-        margin: 0;
-        border-radius: 0;
-      }
-
-      li:hover img {
-        transform: scale(1.05);
-      }
-
-      .content {
-        padding: 1.5rem;
-        flex-grow: 1;
-        display: flex;
-        flex-direction: column;
-      }
-
-      .title {
-        margin: 0 0 0.5rem;
-        color: var(--color-text);
-        line-height: 1.2;
-        font-size: 1.25rem;
-        font-weight: 700;
-        transition: color 0.2s ease;
-      }
-
-      li:hover .title {
-        color: var(--accent);
-      }
-
-      .date {
-        margin: 0;
-        color: rgb(var(--gray));
-        font-size: 0.9rem;
-        margin-bottom: 0.5rem;
-      }
-
-      .description {
-        margin-top: 0.5rem;
-        font-size: 1rem;
-        color: rgb(var(--gray-dark));
-        line-height: 1.5;
-        overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 3;
-        -webkit-box-orient: vertical;
-      }
-
-      .tags {
-        margin-top: auto;
-        padding-top: 1rem;
-      }
-
-      @media (max-width: 1000px) {
-        .layout {
-          grid-template-columns: 1fr;
-          gap: 2rem;
-        }
-        ul {
-          grid-template-columns: 1fr;
-        }
-      }
-    </style>
+    <BaseHead title={`#${tag} | ${SITE_TITLE}`} description={`${tag} 태그가 포함된 글 목록`} />
   </head>
-  <body>
+  <body class="font-body selection:bg-[#00e5ff] selection:text-[#00363d]">
     <Header />
-    <div class="layout">
+    <div class="flex max-w-7xl mx-auto pt-24 min-h-screen">
       <SidebarLeft />
-      <main class="main-content">
-        <section class="page-header animate-fade-in-up">
-          <a href="/tags" class="back-link">← 모든 태그 보기</a>
-          <h1>#{tag}</h1>
-          <p>{posts.length}개의 글이 있습니다.</p>
-        </section>
-        <section class="animate-fade-in-up" style="animation-delay: 0.1s">
-          <ul>
-            {posts.map((post) => {
-              const firstImage = getFirstImage(post.body);
-              const displayImage = post.data.heroImage || firstImage;
+      <main class="flex-1 lg:ml-64 px-6 md:px-12 py-8 pb-24 md:pb-8">
+        <header class="mb-12">
+          <a href="/tags" class="inline-flex items-center gap-1 text-[#849396] hover:text-[#00e5ff] transition-colors font-label text-xs uppercase tracking-widest mb-4 no-underline">
+            <span class="material-symbols-outlined text-base">arrow_back</span>
+            모든 태그
+          </a>
+          <h1 class="text-5xl font-extrabold font-headline tracking-tighter text-[#00e5ff]">#{tag}</h1>
+          <p class="text-[#849396] font-label text-sm mt-2">{posts.length}개의 글</p>
+        </header>
 
-              return (
-                <li class="glass-card">
-                  <a href={`/blog/${post.id}/`}>
-                    <div class="image-container">
-                      {displayImage ? (
-                        <img
-                          src={
-                            typeof displayImage === 'string'
-                              ? displayImage
-                              : displayImage.src
-                          }
-                          alt=""
-                          width="720"
-                          height="360"
-                          loading="lazy"
-                        />
-                      ) : (
-                        <div
-                          style="width:100%; height:100%; background: linear-gradient(135deg, #e0e7ff 0%, #f5f3ff 100%); display:flex; align-items:center; justify-content:center; color: var(--accent);"
-                        >
-                          <span style="font-size: 2rem; font-weight:bold; opacity:0.3;">
-                            Jerry
-                          </span>
-                        </div>
-                      )}
+        <section class="space-y-10">
+          {posts.map((post) => {
+            const image = post.data.heroImage || getFirstImage(post.body);
+            const imageUrl = image ? (typeof image === 'string' ? image : (image as any).src) : null;
+            return (
+              <article class="group grid md:grid-cols-12 gap-6 items-start py-6 hover:bg-[#181c22]/50 rounded-2xl px-4 -mx-4 transition-all">
+                <div class="md:col-span-4 aspect-video rounded-xl overflow-hidden bg-[#262a31]">
+                  {imageUrl ? (
+                    <img class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" src={imageUrl} alt={post.data.title} loading="lazy" />
+                  ) : (
+                    <div class="w-full h-full flex items-center justify-center">
+                      <span class="material-symbols-outlined text-4xl text-[#3b494c]">article</span>
                     </div>
-                    <div class="content">
-                      <h4 class="title">{post.data.title}</h4>
-                      <p class="date">
-                        <FormattedDate date={post.data.pubDate} />
-                      </p>
-                      {post.data.description && (
-                        <p class="description">{post.data.description}</p>
-                      )}
-                      {post.data.tags && post.data.tags.length > 0 && (
-                        <div class="tags">
-                          <TagList tags={post.data.tags} size="sm" clickable={false} />
-                        </div>
-                      )}
-                    </div>
+                  )}
+                </div>
+                <div class="md:col-span-8">
+                  <div class="flex items-center gap-3 mb-3">
+                    <span class="font-label text-[10px] uppercase tracking-widest text-[#849396]">
+                      <FormattedDate date={post.data.pubDate} />
+                    </span>
+                  </div>
+                  <a href={`/blog/${post.id}/`} class="no-underline">
+                    <h2 class="text-xl font-bold font-headline text-[#dfe2eb] group-hover:text-[#00e5ff] transition-colors mb-2">{post.data.title}</h2>
                   </a>
-                </li>
-              );
-            })}
-          </ul>
+                  {post.data.description && (
+                    <p class="text-[#849396] font-body leading-relaxed line-clamp-2">{post.data.description}</p>
+                  )}
+                </div>
+              </article>
+            );
+          })}
         </section>
       </main>
     </div>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -13,108 +13,43 @@ const tags = getTagsWithCount(publishedPosts);
 ---
 
 <!doctype html>
-<html lang="ko">
+<html class="dark" lang="ko">
   <head>
-    <BaseHead title={`Tags - ${SITE_TITLE}`} description={SITE_DESCRIPTION} />
-    <style>
-      .layout {
-        display: grid;
-        grid-template-columns: 280px 1fr;
-        gap: 3rem;
-        max-width: 1200px;
-        margin: 0 auto;
-        padding: 2rem 1rem;
-      }
-      .main-content {
-        min-height: 100vh;
-      }
-
-      .page-header {
-        margin-bottom: 3rem;
-        text-align: center;
-      }
-
-      .page-header h1 {
-        font-size: 2.5rem;
-        margin-bottom: 0.5rem;
-      }
-
-      .page-header p {
-        color: rgb(var(--gray));
-        font-size: 1.1rem;
-      }
-
-      .tags-grid {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 1rem;
-        justify-content: center;
-      }
-
-      .tag-card {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.75rem 1.25rem;
-        text-decoration: none;
-        transition: all 0.2s ease;
-      }
-
-      .tag-card:hover {
-        transform: translateY(-2px);
-        box-shadow: var(--glass-shadow);
-      }
-
-      .tag-name {
-        font-size: 1rem;
-        font-weight: 600;
-        color: var(--color-text);
-      }
-
-      .tag-count {
-        font-size: 0.875rem;
-        font-weight: 500;
-        color: white;
-        background: var(--accent);
-        padding: 0.125rem 0.5rem;
-        border-radius: 99px;
-        min-width: 1.5rem;
-        text-align: center;
-      }
-
-      @media (max-width: 1000px) {
-        .layout {
-          grid-template-columns: 1fr;
-          gap: 2rem;
-        }
-      }
-    </style>
+    <BaseHead title={`Tags | ${SITE_TITLE}`} description={SITE_DESCRIPTION} />
   </head>
-  <body>
+  <body class="font-body selection:bg-[#00e5ff] selection:text-[#00363d]">
     <Header />
-    <div class="layout">
+    <div class="flex max-w-7xl mx-auto pt-24 min-h-screen">
       <SidebarLeft />
-      <main class="main-content">
-        <section class="page-header animate-fade-in-up">
-          <h1>Tags</h1>
-          <p>{tags.length}개의 태그가 있습니다.</p>
-        </section>
-        <section class="animate-fade-in-up" style="animation-delay: 0.1s">
-          {tags.length > 0 ? (
-            <div class="tags-grid">
-              {tags.map((tag) => (
-                <a href={`/tags/${tag.name}/`} class="tag-card glass-card">
-                  <span class="tag-name">#{tag.name}</span>
-                  <span class="tag-count">{tag.count}</span>
-                </a>
-              ))}
-            </div>
-          ) : (
-            <p style="text-align: center; color: rgb(var(--gray));">
-              아직 태그가 없습니다. 글에 태그를 추가해보세요.
-            </p>
-          )}
-        </section>
+      <main class="flex-1 lg:ml-64 px-6 md:px-12 py-8 pb-24 md:pb-8">
+        <header class="mb-12">
+          <span class="font-label text-xs uppercase tracking-[0.3em] text-[#00e5ff] mb-4 block">Categories</span>
+          <h1 class="text-5xl font-extrabold font-headline tracking-tighter text-[#dfe2eb]">Tags</h1>
+          <p class="text-[#849396] font-label text-sm mt-2">{tags.length}개의 태그</p>
+        </header>
+
+        {tags.length > 0 ? (
+          <div class="flex flex-wrap gap-3">
+            {tags.map((tag) => (
+              <a
+                href={`/tags/${tag.name}/`}
+                class="flex items-center gap-2 px-4 py-2.5 rounded-lg bg-[#1c2026] border border-[#3b494c]/20 hover:border-[#00e5ff]/30 hover:bg-[#262a31] transition-all no-underline group"
+              >
+                <span class="text-sm font-label font-medium text-[#dfe2eb] group-hover:text-[#00e5ff] transition-colors">
+                  #{tag.name}
+                </span>
+                <span class="text-xs font-bold font-label text-[#00363d] bg-[#00e5ff] px-1.5 py-0.5 rounded-full min-w-[1.5rem] text-center">
+                  {tag.count}
+                </span>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <div class="text-center py-20">
+            <span class="material-symbols-outlined text-6xl text-[#3b494c] mb-4 block">label</span>
+            <p class="text-[#849396] font-label uppercase tracking-widest text-sm">아직 태그가 없습니다</p>
+          </div>
+        )}
       </main>
     </div>
     <Footer />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,371 +1,223 @@
 /*
-  iOS-INSPIRED DESIGN SYSTEM WITH DARK MODE
- */
+  Stitch Design System - Global Styles
+  색상: tailwind.config (BaseHead.astro) 에서 관리
+*/
 
-:root {
-	/* iOS System Colors - Light Mode */
-	--accent-hue: 211;
-	--accent-sat: 100%;
-	--accent-light: 50%;
-
-	--accent: #007AFF;
-	--accent-dark: #0056b3;
-	--accent-light-translucent: rgba(0, 122, 255, 0.12);
-
-	/* Color tokens */
-	--color-bg: #F2F2F7;
-	--color-bg-secondary: #FFFFFF;
-	--color-text: #1c1c1e;
-	--color-text-secondary: rgb(142, 142, 147);
-	--color-text-tertiary: rgb(28, 28, 30);
-	--color-border: rgba(0, 0, 0, 0.05);
-	--color-code: #FF2D55;
-	--color-code-bg: rgba(118, 118, 128, 0.1);
-
-	/* Legacy support */
-	--black: 0, 0, 0;
-	--gray: 142, 142, 147;
-	--gray-light: 242, 242, 247;
-	--gray-dark: 28, 28, 30;
-
-	/* Glassmorphism / iOS Material */
-	--glass-bg: rgba(255, 255, 255, 0.72);
-	--glass-border: rgba(255, 255, 255, 0.6);
-	--glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.04);
-	--ios-radius: 24px;
-
-	--box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-
-	/* Header background */
-	--header-bg: rgba(255, 255, 255, 0.85);
-
-	/* Background gradients */
-	--bg-gradient-1: hsla(210, 100%, 96%, 1);
-	--bg-gradient-2: hsla(280, 100%, 96%, 1);
-	--bg-gradient-3: hsla(240, 100%, 98%, 1);
-
-	/* Pre/code block */
-	--pre-bg: #1c1c1e;
-	--pre-color: #fff;
-
-	/* Transitions */
-	--transition-theme: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+* {
+  box-sizing: border-box;
 }
 
-/* Dark Mode */
-[data-theme="dark"] {
-	--accent: #0A84FF;
-	--accent-dark: #409CFF;
-	--accent-light-translucent: rgba(10, 132, 255, 0.2);
-
-	--color-bg: #000000;
-	--color-bg-secondary: #1c1c1e;
-	--color-text: #FFFFFF;
-	--color-text-secondary: rgb(142, 142, 147);
-	--color-text-tertiary: rgb(229, 229, 234);
-	--color-border: rgba(255, 255, 255, 0.1);
-	--color-code: #FF375F;
-	--color-code-bg: rgba(118, 118, 128, 0.24);
-
-	/* Legacy support for dark mode */
-	--black: 255, 255, 255;
-	--gray: 142, 142, 147;
-	--gray-light: 28, 28, 30;
-	--gray-dark: 229, 229, 234;
-
-	/* Glassmorphism dark */
-	--glass-bg: rgba(28, 28, 30, 0.72);
-	--glass-border: rgba(255, 255, 255, 0.1);
-	--glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-	--box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-
-	/* Header background dark */
-	--header-bg: rgba(0, 0, 0, 0.85);
-
-	/* Background gradients dark */
-	--bg-gradient-1: hsla(210, 100%, 10%, 1);
-	--bg-gradient-2: hsla(280, 100%, 8%, 1);
-	--bg-gradient-3: hsla(240, 100%, 5%, 1);
-
-	/* Pre/code block dark */
-	--pre-bg: #2c2c2e;
-	--pre-color: #fff;
-}
-
-@font-face {
-	font-family: "Atkinson";
-	src: url("/fonts/atkinson-regular.woff") format("woff");
-	font-weight: 400;
-	font-style: normal;
-	font-display: swap;
-}
-
-@font-face {
-	font-family: "Atkinson";
-	src: url("/fonts/atkinson-bold.woff") format("woff");
-	font-weight: 700;
-	font-style: normal;
-	font-display: swap;
+html {
+  scroll-behavior: smooth;
 }
 
 body {
-	font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-	margin: 0;
-	padding: 0;
-	text-align: left;
-	background: var(--color-bg);
-	background-image:
-		radial-gradient(at 10% 10%, var(--bg-gradient-1) 0px, transparent 50%),
-		radial-gradient(at 90% 0%, var(--bg-gradient-2) 0px, transparent 50%),
-		radial-gradient(at 50% 90%, var(--bg-gradient-3) 0px, transparent 50%);
-	background-size: 100% 100%;
-	background-attachment: fixed;
-	word-wrap: break-word;
-	overflow-wrap: break-word;
-	color: var(--color-text);
-	font-size: 17px;
-	line-height: 1.5;
-	-webkit-font-smoothing: antialiased;
-	min-height: 100vh;
-	transition: var(--transition-theme);
+  margin: 0;
+  padding: 0;
+  background-color: #10141a;
+  color: #dfe2eb;
+  font-family: "Inter", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
-main {
-	width: 800px;
-	max-width: calc(100% - 2em);
-	margin: auto;
-	padding: 3em 1em;
+/* ============================
+   Article / Prose Content
+   (MDX 마크다운 본문 스타일)
+   ============================ */
+
+.prose {
+  color: #bac9cc;
+  font-family: "Newsreader", serif;
+  font-size: 1.125rem;
+  line-height: 1.8;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	margin: 0 0 0.5rem 0;
-	color: var(--color-text);
-	line-height: 1.2;
-	letter-spacing: -0.022rem;
-	transition: var(--transition-theme);
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5,
+.prose h6 {
+  font-family: "Inter", sans-serif;
+  color: #dfe2eb;
+  line-height: 1.2;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
 }
 
-h1 {
-	font-size: 34px;
-	font-weight: 700;
-	border-bottom: none;
+.prose h2 {
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: #00e5ff;
 }
 
-h2 {
-	font-size: 28px;
-	font-weight: 700;
+.prose h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #dfe2eb;
 }
 
-h3 {
-	font-size: 22px;
-	font-weight: 600;
-}
-
-h4 {
-	font-size: 20px;
-	font-weight: 600;
-}
-
-h5 {
-	font-size: 17px;
-	font-weight: 600;
-}
-
-h6 {
-	font-size: 15px;
-	font-weight: 600;
-}
-
-strong,
-b {
-	font-weight: 600;
-}
-
-a {
-	color: var(--accent);
-	text-decoration: none;
-	transition: opacity 0.2s ease, color 0.2s ease;
-}
-
-a:hover {
-	opacity: 0.7;
-	color: var(--accent);
-}
-
-a:active {
-	opacity: 0.5;
-}
-
-p {
-	margin-bottom: 1.5em;
+.prose h4 {
+  font-size: 1.25rem;
+  font-weight: 600;
 }
 
 .prose p {
-	margin-bottom: 1.5em;
+  margin-bottom: 1.5rem;
 }
 
-textarea,
-input {
-	width: 100%;
-	font-size: 17px;
-	padding: 12px 16px;
-	border-radius: 12px;
-	border: none;
-	background: var(--color-code-bg);
-	color: var(--color-text);
-	transition: var(--transition-theme);
+.prose a {
+  color: #00e5ff;
+  text-decoration: underline;
+  text-decoration-color: rgba(0, 229, 255, 0.3);
+  transition: text-decoration-color 0.2s ease;
 }
 
-textarea:focus,
-input:focus {
-	outline: none;
-	background: rgba(118, 118, 128, 0.2);
+.prose a:hover {
+  text-decoration-color: #00e5ff;
 }
 
-table {
-	width: 100%;
+.prose strong,
+.prose b {
+  color: #dfe2eb;
+  font-weight: 700;
 }
 
-img {
-	max-width: 100%;
-	height: auto;
-	border-radius: 16px;
-	box-shadow: var(--box-shadow);
+.prose em {
+  font-style: italic;
 }
 
-code {
-	padding: 0.2em 0.4em;
-	background-color: var(--color-code-bg);
-	color: var(--color-code);
-	border-radius: 6px;
-	font-size: 0.9em;
-	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+.prose ul,
+.prose ol {
+  padding-left: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
-pre {
-	padding: 1.5em;
-	border-radius: 20px;
-	background: var(--pre-bg);
-	color: var(--pre-color);
-	overflow-x: auto;
-	box-shadow: var(--box-shadow);
+.prose li {
+  margin-bottom: 0.5rem;
 }
 
-pre>code {
-	all: unset;
-	color: inherit;
+.prose blockquote {
+  border-left: 4px solid #00e5ff;
+  padding: 0.75rem 1.5rem;
+  margin: 2rem 0;
+  background: rgba(0, 229, 255, 0.05);
+  border-radius: 0 0.5rem 0.5rem 0;
+  font-style: italic;
+  color: #bac9cc;
 }
 
-blockquote {
-	border-left: 4px solid var(--accent);
-	padding: 0.5em 0 0.5em 1.5em;
-	margin: 1.5em 0;
-	background: var(--accent-light-translucent);
-	border-radius: 0 16px 16px 0;
-	font-size: 1.1em;
-	font-style: italic;
+.prose code {
+  font-family: "Space Grotesk", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  background: #0a0e14;
+  color: #00e5ff;
+  padding: 0.2em 0.5em;
+  border-radius: 0.25rem;
+  font-size: 0.875em;
+  border: 1px solid rgba(59, 73, 76, 0.3);
 }
 
-hr {
-	border: none;
-	border-top: 1px solid var(--color-border);
-	margin: 2em 0;
+.prose pre {
+  background: #0a0e14;
+  border: 1px solid rgba(59, 73, 76, 0.2);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  overflow-x: auto;
+  margin: 2rem 0;
 }
 
-/* Utilities */
-.glass-card {
-	background: var(--glass-bg);
-	backdrop-filter: blur(25px) saturate(180%);
-	-webkit-backdrop-filter: blur(25px) saturate(180%);
-	border: 1px solid var(--glass-border);
-	box-shadow: var(--glass-shadow);
-	border-radius: var(--ios-radius);
-	transition: var(--transition-theme);
+.prose pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #dfe2eb;
+  font-size: 0.9rem;
 }
 
-/* Clickable Cards Interaction */
-.glass-card:active {
-	transform: scale(0.98);
-	transition: transform 0.1s ease;
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0;
+  font-size: 0.95rem;
 }
 
-/* Animations */
-@keyframes fadeInUp {
-	from {
-		opacity: 0;
-		transform: translateY(20px) scale(0.98);
-	}
-
-	to {
-		opacity: 1;
-		transform: translateY(0) scale(1);
-	}
+.prose th {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #bac9cc;
+  border-bottom: 1px solid rgba(59, 73, 76, 0.4);
+  padding: 0.75rem 1rem;
+  text-align: left;
 }
 
-.animate-fade-in-up {
-	animation: fadeInUp 0.7s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+.prose td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(59, 73, 76, 0.2);
+  color: #bac9cc;
 }
 
-/* Reduced motion support */
-@media (prefers-reduced-motion: reduce) {
-	*,
-	*::before,
-	*::after {
-		animation-duration: 0.01ms !important;
-		animation-iteration-count: 1 !important;
-		transition-duration: 0.01ms !important;
-	}
-
-	.animate-fade-in-up {
-		animation: none;
-		opacity: 1;
-		transform: none;
-	}
+.prose hr {
+  border: none;
+  border-top: 1px solid rgba(59, 73, 76, 0.3);
+  margin: 3rem 0;
 }
 
-@media (max-width: 720px) {
-	body {
-		font-size: 16px;
-	}
-
-	main {
-		padding: 1em;
-	}
+.prose img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.75rem;
+  margin: 2rem 0;
 }
+
+/* ============================
+   Utilities
+   ============================ */
 
 .sr-only {
-	border: 0;
-	padding: 0;
-	margin: 0;
-	position: absolute !important;
-	height: 1px;
-	width: 1px;
-	overflow: hidden;
-	clip: rect(1px 1px 1px 1px);
-	clip: rect(1px, 1px, 1px, 1px);
-	clip-path: inset(50%);
-	white-space: nowrap;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }
 
-/* Theme toggle animation */
-@keyframes themeToggleSpin {
-	from {
-		transform: rotate(0deg);
-	}
-	to {
-		transform: rotate(360deg);
-	}
+/* Code block with macOS-style dots (Stitch style) */
+.code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: #262a31;
+  border-radius: 0.5rem 0.5rem 0 0;
+  border-bottom: 1px solid rgba(59, 73, 76, 0.2);
 }
 
-.theme-toggle-icon {
-	transition: transform 0.3s ease;
+.code-block-dots {
+  display: flex;
+  gap: 6px;
 }
 
-.theme-toggle:hover .theme-toggle-icon {
-	transform: rotate(15deg);
+.code-block-dots span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }


### PR DESCRIPTION
- Replace iOS-inspired design with Google Stitch dark theme (#10141a bg, #00e5ff accent)
- Add Tailwind CDN with full Stitch color config in BaseHead
- Rewrite Header, Footer, SidebarLeft with Stitch components
- Rewrite all pages (index, blog, about, projects, news, tags, categories) with Stitch dark theme
- Migrate BlogPost layout: TOC moved to right sidebar, comments section removed
- Unify fonts: Inter for all UI (headline/body/label), Space Grotesk for mono, Newsreader for prose
- Fix content.config.ts: add nullable() to description schema
- Fix about.astro: solved.ac API fetch with try/catch fallback, remove unused simpleIcons import
- Fix tech stack badge icon sizing with object-fit: contain